### PR TITLE
Few minor optimizations & bug-fix

### DIFF
--- a/FS19_AutoDrive/scripts/AutoDriveDijkstra.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveDijkstra.lua
@@ -113,6 +113,7 @@ function AutoDrive:dijkstra(Graph, start, setToUse)
 
 	if recalcTable.dijkstraStep == 3 then
 		recalcTable.dijkstraAllowedIteratorQ = 200 / (math.max(0.001, (numberOfWayPoints / (2000 * AutoDrive.getSetting("recalculationSpeed")))))
+		local useFastestRoute = AutoDrive.getSetting("useFastestRoute")
 
 		while recalcTable.dijkstraAllowedIteratorQ > 0 and next(workQ, nil) ~= nil do
 			recalcTable.dijkstraAllowedIteratorQ = recalcTable.dijkstraAllowedIteratorQ - 1
@@ -179,7 +180,7 @@ function AutoDrive:dijkstra(Graph, start, setToUse)
 							end
 
 							local distanceToAdd = 0
-							if AutoDrive.getSetting("useFastestRoute") == true then
+							if useFastestRoute == true then
 								distanceToAdd = AutoDrive:getDriveTimeBetweenNodes(shortest_id, linkedNodeId, workPre[shortest_id], nil, true) --3 points for angle
 							else
 								distanceToAdd = AutoDrive:getDistanceBetweenNodes(shortest_id, linkedNodeId)
@@ -269,18 +270,21 @@ function AutoDrive:dijkstraInit(Graph, start, setToUse)
 	local workQ = workGraph.Q
 	workGraph.workQEntries = AutoDrive.mapWayPointsCounter
 
-	if recalcTable.dijkstraStep == 1 or AutoDrive.getSetting("recalculationSpeed") > 10 then
+	local forcedInit = AutoDrive.getSetting("recalculationSpeed") > 10
+
+	if recalcTable.dijkstraStep == 1 or forcedInit then
 		for i in pairs(Graph) do
 			--workDistances[i] = math.huge;
 			workPre[i] = -1
 		end
 	end
 
-	if recalcTable.dijkstraStep == 2 or AutoDrive.getSetting("recalculationSpeed") > 10 then
+	if recalcTable.dijkstraStep == 2 or forcedInit then
+		local useFastestRoute = AutoDrive.getSetting("useFastestRoute")
 		workDistances[start] = 0
 		for i, id in pairs(workQ[start]) do
 			local distanceToAdd = 0
-			if AutoDrive.getSetting("useFastestRoute") == true then
+			if useFastestRoute == true then
 				distanceToAdd = AutoDrive:getDriveTimeBetweenNodes(start, id, nil, nil, nil) --first segments, only 2 points, no angle
 			else
 				distanceToAdd = AutoDrive:getDistanceBetweenNodes(start, id)
@@ -290,7 +294,7 @@ function AutoDrive:dijkstraInit(Graph, start, setToUse)
 		end
 	end
 
-	if AutoDrive.getSetting("recalculationSpeed") > 50 then
+	if forcedInit then
 		recalcTable.dijkstraStep = 3
 	end
 end

--- a/FS19_AutoDrive/scripts/AutoDriveDriveFuncs.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveDriveFuncs.lua
@@ -426,9 +426,7 @@ function AutoDrive:driveToNextWayPoint(vehicle, dt)
             vehicle.ad.speedOverride = 17
         elseif highestAngle < 20 then
             vehicle.ad.speedOverride = 16
-        elseif highestAngle < 30 then
-            vehicle.ad.speedOverride = 13
-        elseif highestAngle < 90 then
+        else
             vehicle.ad.speedOverride = 13
         end
     end

--- a/FS19_AutoDrive/scripts/AutoDriveSettings.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveSettings.lua
@@ -368,8 +368,8 @@ AutoDrive.settings.smoothField = {
 }
 
 AutoDrive.settings.recalculationSpeed = {
-    values = {0.5, 1, 1.5, 2, 5, 10, 25, 50, 100, 250, 500, 1000},
-    texts = {"x0.5", "x1", "x1.5", "x2", "x5", "x10", "x25", "x100", "x250", "x500", "x1000"},
+    values = { 0.5,    1,    1.5,    2,    5,    10,    25,    50,    100,    250,    500,    1000},
+    texts = {"x0.5", "x1", "x1.5", "x2", "x5", "x10", "x25", "x50", "x100", "x250", "x500", "x1000"},
     default = 2,
     current = 2,
     text = "gui_ad_recalculationSpeed",


### PR DESCRIPTION
- Fix for `settings.recalculationSpeed.texts` missing "x50"
- Removal of method `sortNodesByDistance` as its not used
- Using `table.insert` for appending to existing array, instead of the _"first count number of elements, then use number as the index for adding new element"_
- Caching value returned from `getSettings`, especially in loops.
- Refactored methods `FastShortestPath`, `graphcopy` & `createNode`, to be a bit more readable (I hope).