### PR TITLE
Minor optimizations for AutoDriveHud

### DIFF
--- a/FS19_AutoDrive/scripts/AutoDrive.lua
+++ b/FS19_AutoDrive/scripts/AutoDrive.lua
@@ -121,6 +121,7 @@ function AutoDrive:loadMap(name)
 	AutoDrive.groupCounter = 1
 
 	AutoDrive.pullDownListExpanded = 0
+	AutoDrive.pullDownListDirection = 0
 
 	AutoDrive.lastSetSpeed = 50
 

--- a/FS19_AutoDrive/scripts/AutoDriveHud.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveHud.lua
@@ -195,6 +195,11 @@ function AutoDriveHud:createHudAt(hudX, hudY)
 
 	--local continueX = self.posX + (self.cols - 3) * self.borderX + (self.cols - 4) * self.buttonWidth;
 	--table.insert(self.hudElements, ADHudButton:new(continueX, self.row4, self.buttonWidth, self.buttonHeight, "input_continue", nil, "input_AD_continue", 1, true));
+
+	-- Sort the elements by their layer index, for optimizing drawHud and mouseEvent methods
+	table.sort(self.hudElements, function(a,b)
+		return a.layer < b.layer
+	end)
 end
 
 function AutoDriveHud:AddButton(primaryAction, secondaryAction, toolTip, state, visible)
@@ -230,14 +235,8 @@ function AutoDriveHud:drawHud(vehicle)
 		local ovWidth = self.Background.width
 		local ovHeight = self.Background.height
 
-		local layer = 0
-		while layer <= 10 do
-			for id, element in pairs(self.hudElements) do
-				if element.layer == layer then
-					element:onDraw(vehicle)
-				end
-			end
-			layer = layer + 1
+		for _, element in ipairs(self.hudElements) do  -- `ipairs` is important, as we want "index-value pairs", not "key-value pairs". https://stackoverflow.com/a/55109411
+			element:onDraw(vehicle, uiScale)
 		end
 	end
 end
@@ -260,17 +259,14 @@ function AutoDriveHud:mouseEvent(vehicle, posX, posY, isDown, isUp, button)
 	if mouseActiveForAutoDrive then
 		local mouseEventHandled = false
 		AutoDrive.mouseWheelActive = false
-		local layer = 10
-		while layer >= 0 and (not mouseEventHandled) do
-			for id, element in pairs(self.hudElements) do
-				if element.layer == layer then
-					mouseEventHandled = mouseEventHandled or element:mouseEvent(vehicle, posX, posY, isDown, isUp, button, layer)
-				end
-				if mouseEventHandled then
-					break
-				end
+		-- Start with highest layer value (last in array), and then iterate backwards.
+		for i=#self.hudElements,1,-1 do
+			local element = self.hudElements[i]
+			local layer = element.layer
+			mouseEventHandled = element:mouseEvent(vehicle, posX, posY, isDown, isUp, button, layer)
+			if mouseEventHandled then
+				break
 			end
-			layer = layer - 1
 		end
 
 		if (not mouseEventHandled) and (AutoDrive.pullDownListExpanded > 0) and (button >= 1 and button <= 3 and isUp) then

--- a/FS19_AutoDrive/scripts/AutoDriveHud.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveHud.lua
@@ -196,10 +196,8 @@ function AutoDriveHud:createHudAt(hudX, hudY)
 	--local continueX = self.posX + (self.cols - 3) * self.borderX + (self.cols - 4) * self.buttonWidth;
 	--table.insert(self.hudElements, ADHudButton:new(continueX, self.row4, self.buttonWidth, self.buttonHeight, "input_continue", nil, "input_AD_continue", 1, true));
 
-	-- Sort the elements by their layer index, for optimizing drawHud and mouseEvent methods
-	table.sort(self.hudElements, function(a,b)
-		return a.layer < b.layer
-	end)
+	-- Refreshing layer sequence must be called, after all elements have been added
+	self:refreshHudElementsLayerSequence()
 end
 
 function AutoDriveHud:AddButton(primaryAction, secondaryAction, toolTip, state, visible)
@@ -214,6 +212,13 @@ function AutoDriveHud:AddButton(primaryAction, secondaryAction, toolTip, state, 
 	local posY = self.posY + (self.rowCurrent) * self.borderY + (self.rowCurrent - 1) * self.buttonHeight
 	local tooltip = string.sub(g_i18n:getText(toolTip), 4, string.len(g_i18n:getText(toolTip)))
 	table.insert(self.hudElements, ADHudButton:new(posX, posY, self.buttonWidth, self.buttonHeight, primaryAction, secondaryAction, toolTip, state, visible))
+end
+
+function AutoDriveHud:refreshHudElementsLayerSequence()
+	-- Sort the elements by their layer index, for optimizing drawHud and mouseEvent methods
+	table.sort(self.hudElements, function(a,b)
+		return a.layer < b.layer
+	end)
 end
 
 function AutoDriveHud:drawHud(vehicle)
@@ -265,6 +270,8 @@ function AutoDriveHud:mouseEvent(vehicle, posX, posY, isDown, isUp, button)
 			local layer = element.layer
 			mouseEventHandled = element:mouseEvent(vehicle, posX, posY, isDown, isUp, button, layer)
 			if mouseEventHandled then
+				-- Maybe a PullDownList have been expanded/collapsed, so need to refresh layer sequence
+				self:refreshHudElementsLayerSequence()
 				break
 			end
 		end
@@ -340,6 +347,8 @@ function AutoDriveHud:closeAllPullDownLists(vehicle)
 			hudElement:collapse(vehicle, false)
 		end
 	end
+	-- PullDownList(s) have been collapsed, so need to refresh layer sequence
+	self:refreshHudElementsLayerSequence()
 end
 
 --blatant copy of Courseplay's implementation. So all credit goes to their dev team :-)

--- a/FS19_AutoDrive/scripts/HudElements/GenericHudElement.lua
+++ b/FS19_AutoDrive/scripts/HudElements/GenericHudElement.lua
@@ -21,7 +21,7 @@ function ADGenericHudElement:mouseEvent(vehicle, posX, posY, isDown, isUp, butto
     return false
 end
 
-function ADGenericHudElement:onDraw(vehicle)
+function ADGenericHudElement:onDraw(vehicle, uiScale)
 end
 
 function ADInheritsFrom(baseClass)

--- a/FS19_AutoDrive/scripts/HudElements/HudButton.lua
+++ b/FS19_AutoDrive/scripts/HudElements/HudButton.lua
@@ -28,7 +28,7 @@ function ADHudButton:readImages()
     return images
 end
 
-function ADHudButton:onDraw(vehicle)
+function ADHudButton:onDraw(vehicle, uiScale)
     self:updateState(vehicle)
     if self.isVisible then
         self.ov:render()
@@ -187,6 +187,9 @@ end
 
 function ADHudButton:act(vehicle, posX, posY, isDown, isUp, button)
     if self.isVisible then
+        vehicle.ad.sToolTip = self.toolTip
+        vehicle.ad.nToolTipWait = 5
+
         if button == 1 and isUp then
             AutoDrive:InputHandling(vehicle, self.primaryAction)
             AutoDrive:InputHandlingSenderOnly(vehicle, self.primaryAction)
@@ -195,11 +198,6 @@ function ADHudButton:act(vehicle, posX, posY, isDown, isUp, button)
             AutoDrive:InputHandling(vehicle, self.secondaryAction)
             AutoDrive:InputHandlingSenderOnly(vehicle, self.secondaryAction)
             return true
-        end
-
-        if (not isDown) and (not isUp) and self.isVisible then
-            vehicle.ad.sToolTip = self.toolTip
-            vehicle.ad.nToolTipWait = 5
         end
     end
 

--- a/FS19_AutoDrive/scripts/HudElements/HudIcon.lua
+++ b/FS19_AutoDrive/scripts/HudElements/HudIcon.lua
@@ -13,13 +13,13 @@ function ADHudIcon:new(posX, posY, width, height, image, layer, name)
     return self
 end
 
-function ADHudIcon:onDraw(vehicle)
+function ADHudIcon:onDraw(vehicle, uiScale)
     self:updateVisibility(vehicle)
 
     self:updateIcon(vehicle)
 
     if self.name == "header" then
-        self:onDrawHeader(vehicle)
+        self:onDrawHeader(vehicle, uiScale)
     end
 
     if self.isVisible then
@@ -27,11 +27,7 @@ function ADHudIcon:onDraw(vehicle)
     end
 end
 
-function ADHudIcon:onDrawHeader(vehicle)
-    local uiScale = g_gameSettings:getValue("uiScale")
-    if AutoDrive.getSetting("guiScale") ~= 0 then
-        uiScale = AutoDrive.getSetting("guiScale")
-    end
+function ADHudIcon:onDrawHeader(vehicle, uiScale)
     local adFontSize = 0.009 * uiScale
     local textHeight = getTextHeight(adFontSize, "text")
     local adPosX = self.position.x + AutoDrive.Hud.gapWidth

--- a/FS19_AutoDrive/scripts/HudElements/HudSpeedmeter.lua
+++ b/FS19_AutoDrive/scripts/HudElements/HudSpeedmeter.lua
@@ -15,21 +15,16 @@ function ADHudSpeedmeter:new(posX, posY, width, height)
     return self
 end
 
-function ADHudSpeedmeter:onDraw(vehicle)
+function ADHudSpeedmeter:onDraw(vehicle, uiScale)
     self.ov:render()
 
-    local uiScale = g_gameSettings:getValue("uiScale")
-    if AutoDrive.getSetting("guiScale") ~= 0 then
-        uiScale = AutoDrive.getSetting("guiScale")
-    end
-    local adFontSize = AutoDrive.FONT_SCALE * uiScale
-    setTextColor(1, 1, 1, 1)
-    setTextAlignment(RenderText.ALIGN_LEFT)
-    local text = string.format("%1d", g_i18n:getSpeed(vehicle.ad.targetSpeed))
-    local textWidth = getTextWidth(adFontSize, text)
-    local posX = self.position.x + (self.size.width - textWidth) / 2 -- -0.012
-    local posY = self.position.y + AutoDrive.Hud.gapHeight
     if AutoDrive.pullDownListExpanded == 0 or AutoDrive.Hud.targetPullDownList.direction == ADPullDownList.EXPANDED_UP then
+        local adFontSize = AutoDrive.FONT_SCALE * uiScale
+        setTextColor(1, 1, 1, 1)
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        local text = string.format("%1d", g_i18n:getSpeed(vehicle.ad.targetSpeed))
+        local posX = self.position.x + (self.size.width / 2)
+        local posY = self.position.y + AutoDrive.Hud.gapHeight
         renderText(posX, posY, adFontSize, text)
     end
 end

--- a/FS19_AutoDrive/scripts/HudElements/PullDownList.lua
+++ b/FS19_AutoDrive/scripts/HudElements/PullDownList.lua
@@ -63,7 +63,7 @@ function ADPullDownList:new(posX, posY, width, height, type, selected)
     return self
 end
 
-function ADPullDownList:onDraw(vehicle)
+function ADPullDownList:onDraw(vehicle, uiScale)
     if not (self.type ~= ADPullDownList.TYPE_FILLTYPE or vehicle.ad.mode == AutoDrive.MODE_LOAD or vehicle.ad.mode == AutoDrive.MODE_PICKUPANDDELIVER) then
         return
     end
@@ -71,10 +71,7 @@ function ADPullDownList:onDraw(vehicle)
     if self.isVisible == false then
         return
     end
-    local uiScale = g_gameSettings:getValue("uiScale")
-    if AutoDrive.getSetting("guiScale") ~= 0 then
-        uiScale = AutoDrive.getSetting("guiScale")
-    end
+
     local adFontSize = AutoDrive.FONT_SCALE * uiScale
     setTextColor(1, 1, 1, 1)
     setTextBold(false)
@@ -124,7 +121,7 @@ function ADPullDownList:onDraw(vehicle)
         self.ovStretch:render()
         self.ovBottom:render()
         --AutoDrive.pullDownListExpanded = self.type;
-        
+
         for i = 1, ADPullDownList.MAX_SHOWN, 1 do
             local listEntry = self:getListElementByDisplayIndex(vehicle, i)
             if listEntry ~= nil then
@@ -147,7 +144,7 @@ function ADPullDownList:onDraw(vehicle)
                 else
                     textTargetWidth = math.abs(self.rightIconPos.x - self.position.x) + AutoDrive.Hud.gapWidth
                 end
-                text = self:shortenTextToWidth(text, textTargetWidth)
+                text = self:shortenTextToWidth(text, textTargetWidth, uiScale)
 
                 local textPosition = self:getTextPositionByDisplayIndex(i)
 
@@ -171,12 +168,12 @@ function ADPullDownList:onDraw(vehicle)
                             end
                         else
                             listEntry.ovPlus = Overlay:new(self.imagePlus, self.rightIconPos3.x, textPosition.y, self.iconSize.width, self.iconSize.height)
-                            listEntry.ovPlus:render()                             
+                            listEntry.ovPlus:render()
                             listEntry.ovFilter = Overlay:new(self.imageFilter, self.rightIconPos4.x, textPosition.y, self.iconSize.width, self.iconSize.height)
                             listEntry.ovFilter:render()
                         end
                     else
-                        if (listEntry.displayName == "All") then                             
+                        if (listEntry.displayName == "All") then
                             listEntry.ovFilter = Overlay:new(self.imageFilter, self.rightIconPos2.x, textPosition.y, self.iconSize.width, self.iconSize.height)
                             listEntry.ovFilter:render()
                         end
@@ -213,16 +210,12 @@ function ADPullDownList:onDraw(vehicle)
     end
 end
 
-function ADPullDownList:shortenTextToWidth(textInput, width)
+function ADPullDownList:shortenTextToWidth(textInput, width, uiScale)
     local text = textInput
     if textInput == nil then
         return ""
     end
 
-    local uiScale = g_gameSettings:getValue("uiScale")
-    if AutoDrive.getSetting("guiScale") ~= 0 then
-        uiScale = AutoDrive.getSetting("guiScale")
-    end
     local adFontSize = AutoDrive.FONT_SCALE * uiScale
 
     local textWidth = getTextWidth(adFontSize, text)
@@ -774,7 +767,7 @@ function ADPullDownList:moveCurrentElementToFolder(vehicle, hitElement)
     local mapMarkerName = vehicle.ad.nameOfSelectedTarget
     local targetGroupName = hitElement.returnValue
 
-    if self.type == ADPullDownList.TYPE_UNLOAD then        
+    if self.type == ADPullDownList.TYPE_UNLOAD then
         mapMarkerID = vehicle.ad.mapMarkerSelected_Unload;
         mapMarkerName = vehicle.ad.nameOfSelectedTarget_Unload;
     end;

--- a/FS19_AutoDrive/scripts/HudElements/PullDownList.lua
+++ b/FS19_AutoDrive/scripts/HudElements/PullDownList.lua
@@ -81,6 +81,13 @@ function ADPullDownList:onDraw(vehicle, uiScale)
         self.ovBG:render()
         self.ovExpand:render()
 
+        if  (AutoDrive.pullDownListExpanded ~= 0)
+        and ((AutoDrive.pullDownListExpanded > self.type and AutoDrive.pullDownListDirection == ADPullDownList.EXPANDED_UP) or
+             (AutoDrive.pullDownListExpanded < self.type and AutoDrive.pullDownListDirection == ADPullDownList.EXPANDED_DOWN)) then
+            -- Do not draw text, as other pull-down-list is expanded and "blocks" the visiblity of this text
+            return
+        end
+
         local text = self.text
         local textWidth = getTextWidth(adFontSize, text)
         while textWidth > (self.size.width - 3 * AutoDrive.Hud.gapWidth - self.iconSize.width) do
@@ -113,9 +120,7 @@ function ADPullDownList:onDraw(vehicle, uiScale)
             end
         end
 
-        if not (AutoDrive.pullDownListExpanded > self.type and self.direction == ADPullDownList.EXPANDED_UP) and not (AutoDrive.pullDownListExpanded < self.type and self.direction == ADPullDownList.EXPANDED_DOWN and (AutoDrive.pullDownListExpanded ~= 0)) then
-            renderText(posX, posY, adFontSize, text)
-        end
+        renderText(posX, posY, adFontSize, text)
     else
         self.ovTop:render()
         self.ovStretch:render()
@@ -592,6 +597,7 @@ function ADPullDownList:expand(vehicle)
     self.state = ADPullDownList.STATE_EXPANDED
 
     AutoDrive.pullDownListExpanded = self.type
+    AutoDrive.pullDownListDirection = self.direction
 
     --possibly adjust height to number of elements (visible)
     self.expandedSize.height = math.min(self:getItemCount(), ADPullDownList.MAX_SHOWN) * AutoDrive.Hud.listItemHeight + self.size.height / 2


### PR DESCRIPTION
- Orders the `hudElements` array after layer-index, to remove excessive loop in `drawHud` and `mouseEvent`
- Calculates `uiScale` only once, then provide it as argument to the `onDraw`methods
- Refactored & slightly optimized `ADHudSpeedmeter:onDraw`