### PR TITLE
Optimizations for AdHud-elements

### DIFF
--- a/FS19_AutoDrive/scripts/HudElements/HudButton.lua
+++ b/FS19_AutoDrive/scripts/HudElements/HudButton.lua
@@ -37,9 +37,7 @@ end
 
 function ADHudButton:updateState(vehicle)
     local newState = self:getNewState(vehicle)
-    if newState ~= self.state then
-        self.ov = Overlay:new(self.images[newState], self.position.x, self.position.y, self.size.width, self.size.height)
-    end
+    self.ov:setImage(self.images[newState])
     self.state = newState
 end
 

--- a/FS19_AutoDrive/scripts/HudElements/HudIcon.lua
+++ b/FS19_AutoDrive/scripts/HudElements/HudIcon.lua
@@ -85,7 +85,7 @@ function ADHudIcon:onDrawHeader(vehicle, uiScale)
     if textWidth > self.size.width - 4 * AutoDrive.Hud.gapWidth then
         --expand header bar and split text
         if self.isExpanded == nil or self.isExpanded == false then
-            self.ov = Overlay:new(self.image, self.position.x, self.position.y, self.size.width, self.size.height + textHeight + AutoDrive.Hud.gapHeight)
+            self.ov:setDimension(nil, self.size.height + textHeight + AutoDrive.Hud.gapHeight)
             self.isExpanded = true
         end
 
@@ -128,7 +128,7 @@ function ADHudIcon:onDrawHeader(vehicle, uiScale)
     else
         if self.isExpanded ~= nil and self.isExpanded == true then
             self.isExpanded = false
-            self.ov = Overlay:new(self.image, self.position.x, self.position.y, self.size.width, self.size.height)
+            self.ov:resetDimensions()
         end
 
         if AutoDrive.pullDownListExpanded == 0 then
@@ -169,8 +169,6 @@ function ADHudIcon:updateIcon(vehicle)
             newIcon = AutoDrive.directory .. "textures/tipper_overlay.dds"
         elseif vehicle.ad.mode == AutoDrive.MODE_UNLOAD then
             newIcon = AutoDrive.directory .. "textures/tipper_overlay.dds"
-        else
-            newIcon = nil
         end
     elseif self.name == "destinationOverlay" then
         if vehicle.ad.mode == AutoDrive.MODE_PICKUPANDDELIVER then
@@ -179,13 +177,9 @@ function ADHudIcon:updateIcon(vehicle)
             newIcon = AutoDrive.directory .. "textures/tipper_overlay.dds"
         elseif vehicle.ad.mode ~= AutoDrive.MODE_BGA then
             newIcon = AutoDrive.directory .. "textures/destination.dds"
-        else
-            newIcon = nil
         end
     end
 
-    if newIcon ~= self.image then
-        self.image = newIcon
-        self.ov = Overlay:new(self.image, self.position.x, self.position.y, self.size.width, self.size.height)
-    end
+    self.image = newIcon
+    self.ov:setImage(self.image)
 end


### PR DESCRIPTION
- Reduced to only one call to `AutoDrive.tableLength` in `ADPullDownList.onDraw`, as this was quite a "high score" on the Script Stats (F8) in-game, when doing delivery runs.
  - Still some optimization could be done, to completely avoid the loop through `mapMarker`-array in this draw method.
- Reduced the amount of creations (and deletions) of Overlay objects, when a pull-down-list is expanded, by directly using game engine's `renderOverlay` API method.
- Changed to using Overlay's `setImage`, 'setDimension' & 'resetDimensions' method, to avoid creation/deletion of these Overlay objects.
- Refactored `shortenTextToWidth` method, to use game engine's `getTextLineLength` API method.