### PR TITLE
Improved external interface

### DIFF
--- a/FS19_AutoDrive/register.lua
+++ b/FS19_AutoDrive/register.lua
@@ -73,7 +73,7 @@ for eName, eId in pairs(EventIds) do
 end
 
 function AutoDriveRegister:loadMap(name)
-	g_logManager:info("[AutoDrive] Loaded mod version %s (by Stephan)", self.version)
+	g_logManager:info("[AutoDrive] Loaded mod version %s (by Stephan). Full version number: %s", self.version, AutoDrive.version)
 end
 
 function AutoDriveRegister:deleteMap()

--- a/FS19_AutoDrive/scripts/AutoDrive.lua
+++ b/FS19_AutoDrive/scripts/AutoDrive.lua
@@ -1,5 +1,5 @@
 AutoDrive = {}
-AutoDrive.version = "1.0.7.0-36"
+AutoDrive.version = "1.0.7.0-37"
 AutoDrive.directory = g_currentModDirectory
 
 g_autoDriveUIFilename = AutoDrive.directory .. "textures/GUI_Icons.dds"
@@ -547,6 +547,12 @@ end
 
 function AutoDrive:onFillTypeSelection(superFunc, fillType)
 	if fillType ~= nil and fillType ~= FillType.UNKNOWN then
+		for _, fillableObject in pairs(self.fillableObjects) do	--copied from gdn getIsActivatable to get a valid Fillable Object even without entering vehicle (needed for refuel first time)
+			if fillableObject.object:getFillUnitSupportsToolType(fillableObject.fillUnitIndex, ToolType.TRIGGER) then
+				self.validFillableObject = fillableObject.object
+				self.validFillableFillUnitIndex = fillableObject.fillUnitIndex
+            end
+        end
 		local validFillableObject = self.validFillableObject
 		if validFillableObject ~= nil then --and validFillableObject:getRootVehicle() == g_currentMission.controlledVehicle
 			local fillUnitIndex = self.validFillableFillUnitIndex

--- a/FS19_AutoDrive/scripts/AutoDriveDriveFuncs.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveDriveFuncs.lua
@@ -724,7 +724,7 @@ function AutoDrive:getLookAheadTarget(vehicle)
 end
 
 function AutoDrive.handleRefueling(vehicle, dt)
-    if AutoDrive.Triggers == nil or (vehicle.ad.isActive == false) or (not AutoDrive.getSetting("autoRefuel", vehicle)) then
+    if AutoDrive.Triggers == nil or (((vehicle.ad.isActive == false) or (not AutoDrive.getSetting("autoRefuel", vehicle))) and not vehicle.ad.onRouteToRefuel) then
         return
     end
     if AutoDrive.hasToRefuel(vehicle) and (not vehicle.ad.onRouteToRefuel) and (not AutoDrive:isOnField(vehicle)) then

--- a/FS19_AutoDrive/scripts/AutoDriveExternalInterface.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveExternalInterface.lua
@@ -119,13 +119,15 @@ function AutoDrive:StartDriving(vehicle, destinationID, unloadDestinationID, cal
                 vehicle.ad.mapMarkerSelected_Unload = unloadDestinationID
                 vehicle.ad.targetSelected_Unload = AutoDrive.mapMarker[vehicle.ad.mapMarkerSelected_Unload].id
                 vehicle.ad.nameOfSelectedTarget_Unload = AutoDrive.mapMarker[vehicle.ad.mapMarkerSelected_Unload].name
-            else
+				AutoDrive:startAD(vehicle)
+            elseif unloadDestinationID == -3 then --park
                 --must be using 'Drive' mode if only one destination is supplied. For now, also set the onRouteToPark variable to true, so AD will shutdown motor and lights on arrival
                 vehicle.ad.mode = 1
+				AutoDrive:startAD(vehicle)
                 vehicle.ad.onRouteToPark = true
+			else	--unloadDestinationID == -2 refuel
+				AutoDrive:startAD(vehicle)
             end
-
-            AutoDrive:startAD(vehicle)
         end
     end
 end
@@ -133,10 +135,38 @@ end
 function AutoDrive:StartDrivingWithPathFinder(vehicle, destinationID, unloadDestinationID, callBackObject, callBackFunction, callBackArg)
     AutoDrive.debugPrint(vehicle, AutoDrive.DC_EXTERNALINTERFACEINFO, "AutoDrive:StartDrivingWithPathFinder(%s, %s, %s, %s, %s)", destinationID, unloadDestinationID, callBackObject, callBackFunction, callBackArg)
     if vehicle ~= nil and vehicle.ad ~= nil and vehicle.ad.isActive == false then
-        AutoDrive:StartDriving(vehicle, destinationID, unloadDestinationID, callBackObject, callBackFunction, callBackArg)
-        vehicle.ad.usePathFinder = true
-        local ignoreFruit = false
-        AutoDrivePathFinder:startPathPlanningToStartPosition(vehicle, nil, ignoreFruit)
+		if unloadDestinationID < -1 then
+			if unloadDestinationID == -3 then	--park
+				local PreviousStartPosition = vehicle.ad.mapMarkerSelected
+				AutoDrive:StartDriving(vehicle, destinationID, unloadDestinationID, callBackObject, callBackFunction, callBackArg)
+				vehicle.ad.usePathFinder = true
+				local ignoreFruit = false
+				AutoDrivePathFinder:startPathPlanningToStartPosition(vehicle, nil, ignoreFruit, PreviousStartPosition)
+			elseif unloadDestinationID == -2 then	--refuel
+				local driverWorldX, driverWorldY, driverWorldZ = getWorldTranslation(vehicle.components[1].node)
+				vehicle.ad.storedMapMarkerSelected = vehicle.ad.mapMarkerSelected
+				vehicle.ad.storedMode = vehicle.ad.mode
+
+				local refuelDestination = AutoDrive.getClosestRefuelDestination(vehicle)
+
+				if refuelDestination ~= nil then
+					vehicle.ad.mapMarkerSelected = refuelDestination
+					vehicle.ad.targetSelected = AutoDrive.mapMarker[vehicle.ad.mapMarkerSelected].id
+					vehicle.ad.nameOfSelectedTarget = AutoDrive.mapMarker[vehicle.ad.mapMarkerSelected].name
+					vehicle.ad.mode = 1
+					vehicle.ad.onRouteToRefuel = true
+					AutoDrive:StartDriving(vehicle, vehicle.ad.mapMarkerSelected, unloadDestinationID, callBackObject, callBackFunction, callBackArg)
+					vehicle.ad.usePathFinder = true
+					local ignoreFruit = false
+					AutoDrivePathFinder:startPathPlanningToStartPosition(vehicle, nil, ignoreFruit, vehicle.ad.storedMapMarkerSelected)
+				end
+			end
+		else
+			AutoDrive:StartDriving(vehicle, destinationID, unloadDestinationID, callBackObject, callBackFunction, callBackArg)
+			vehicle.ad.usePathFinder = true
+			local ignoreFruit = false
+			AutoDrivePathFinder:startPathPlanningToStartPosition(vehicle, nil, ignoreFruit, nil)
+		end
     end
 end
 

--- a/FS19_AutoDrive/scripts/AutoDrivePathFinder.lua
+++ b/FS19_AutoDrive/scripts/AutoDrivePathFinder.lua
@@ -152,7 +152,7 @@ function AutoDrivePathFinder:startPathPlanningToCombine(driver, combine, dischar
     driver.ad.pf.restrictToField = startIsOnField and endIsOnField
 end
 
-function AutoDrivePathFinder:startPathPlanningToStartPosition(driver, combine, ignoreFruit)
+function AutoDrivePathFinder:startPathPlanningToStartPosition(driver, combine, ignoreFruit, PreviousStartPosition)
     --g_logManager:devInfo("startPathPlanningToStartPosition " .. driver.ad.driverName );
     local driverWorldX, driverWorldY, driverWorldZ = getWorldTranslation(driver.components[1].node)
     local driverRx, _, driverRz = localDirectionToWorld(driver.components[1].node, 0, 0, 1)
@@ -161,10 +161,15 @@ function AutoDrivePathFinder:startPathPlanningToStartPosition(driver, combine, i
     local startZ = driverWorldZ + AutoDrive.PATHFINDER_START_DISTANCE * driverRz
 
     local targetPoint = AutoDrive.mapWayPoints[AutoDrive.mapMarker[driver.ad.mapMarkerSelected].id]
-    local preTargetPoint = AutoDrive.mapWayPoints[targetPoint.incoming[1]]
-    local targetVector = {}
-    local waypointsToUnload = AutoDrive:FastShortestPath(AutoDrive.mapWayPoints, AutoDrive.mapMarker[driver.ad.mapMarkerSelected].id, AutoDrive.mapMarker[driver.ad.mapMarkerSelected_Unload].name, AutoDrive.mapMarker[driver.ad.mapMarkerSelected_Unload].id)
-    if waypointsToUnload ~= nil and waypointsToUnload[6] ~= nil then
+	local preTargetPoint = AutoDrive.mapWayPoints[targetPoint.incoming[1]]
+	local targetVector = {}
+	local waypointsToUnload = AutoDrive:FastShortestPath(AutoDrive.mapWayPoints, AutoDrive.mapMarker[driver.ad.mapMarkerSelected].id, AutoDrive.mapMarker[driver.ad.mapMarkerSelected_Unload].name, AutoDrive.mapMarker[driver.ad.mapMarkerSelected_Unload].id)
+    if PreviousStartPosition ~= nil then
+		targetPoint = AutoDrive.mapWayPoints[AutoDrive.mapMarker[PreviousStartPosition].id]
+		preTargetPoint = AutoDrive.mapWayPoints[targetPoint.incoming[1]]
+		waypointsToUnload = AutoDrive:FastShortestPath(AutoDrive.mapWayPoints, AutoDrive.mapMarker[PreviousStartPosition].id, AutoDrive.mapMarker[driver.ad.mapMarkerSelected].name, AutoDrive.mapMarker[driver.ad.mapMarkerSelected].id)
+ 	end
+	if waypointsToUnload ~= nil and waypointsToUnload[6] ~= nil then
         preTargetPoint = AutoDrive.mapWayPoints[waypointsToUnload[1].id]
         targetPoint = AutoDrive.mapWayPoints[waypointsToUnload[2].id]
     end

--- a/FS19_AutoDrive/scripts/AutoDriveTrailerUtil.lua
+++ b/FS19_AutoDrive/scripts/AutoDriveTrailerUtil.lua
@@ -316,17 +316,19 @@ end
 
 function AutoDrive.getTrailersOfImplement(attachedImplement, onlyDischargeable)
     if ((attachedImplement.typeDesc == g_i18n:getText("typeDesc_tipper") or attachedImplement.spec_dischargeable ~= nil) or (not onlyDischargeable)) and attachedImplement.getFillUnits ~= nil then
-        local trailer = attachedImplement
-        AutoDrive.tempTrailerCount = AutoDrive.tempTrailerCount + 1
-        AutoDrive.tempTrailers[AutoDrive.tempTrailerCount] = trailer
+		if not (attachedImplement.vehicleType.specializationsByName["leveler"] ~= nil or attachedImplement.typeDesc == "frontloaderTool") then	--avoid trying to fill shovels and levellers atached
+			local trailer = attachedImplement
+			AutoDrive.tempTrailerCount = AutoDrive.tempTrailerCount + 1
+			AutoDrive.tempTrailers[AutoDrive.tempTrailerCount] = trailer
+		end
     end
-    if attachedImplement.vehicleType.specializationsByName["hookLiftTrailer"] ~= nil then
+    --[[if attachedImplement.vehicleType.specializationsByName["hookLiftTrailer"] ~= nil then			--not needed since checking every single implement, counts fillLevel as double for hooklift containers
         if attachedImplement.spec_hookLiftTrailer.attachedContainer ~= nil then
             local trailer = attachedImplement.spec_hookLiftTrailer.attachedContainer.object
             AutoDrive.tempTrailerCount = AutoDrive.tempTrailerCount + 1
             AutoDrive.tempTrailers[AutoDrive.tempTrailerCount] = trailer
         end
-    end
+    end]]--
 
     if attachedImplement.getAttachedImplements ~= nil then
         for _, implement in pairs(attachedImplement:getAttachedImplements()) do


### PR DESCRIPTION
Doesn´t crash with previous versions of CP, but should update it to new version to get it fully working (pull request already acepted)
Exit field with pathfinding to previously selected target (field) for parking or refueling CoursePlay

Also fixed bug: try to fill shovels or levelers and double counting hooklift filllevel