### PR TITLE
Feature/remove save dialog

### DIFF
--- a/AutoDrive Course Editor/src/main/java/de/adEditor/AutoDriveEditor.java
+++ b/AutoDrive Course Editor/src/main/java/de/adEditor/AutoDriveEditor.java
@@ -460,6 +460,7 @@ public class AutoDriveEditor extends JFrame {
         {
             saveXmlConfig(xmlConfigFile, roadMap);
             setStale(false);
+            JOptionPane.showMessageDialog(this, xmlConfigFile.getName() + " has been successfully saved.", "AutoDrive", JOptionPane.INFORMATION_MESSAGE);
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
             JOptionPane.showMessageDialog(this, "The AutoDrive Config could not be saved.", "AutoDrive", JOptionPane.ERROR_MESSAGE);

--- a/AutoDrive Course Editor/src/main/java/de/adEditor/EditorListener.java
+++ b/AutoDrive Course Editor/src/main/java/de/adEditor/EditorListener.java
@@ -2,22 +2,20 @@ package de.adEditor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 
 import javax.imageio.ImageIO;
 import javax.swing.*;
-import javax.xml.parsers.ParserConfigurationException;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.File;
 import java.io.IOException;
 
 public class EditorListener implements ActionListener {
 
     private static Logger LOG = LoggerFactory.getLogger(EditorListener.class);
     public AutoDriveEditor editor;
-
-    final JFileChooser fc = new JFileChooser();
 
     public EditorListener (AutoDriveEditor editor) {
         this.editor = editor;
@@ -27,12 +25,7 @@ public class EditorListener implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         LOG.info("ActionCommand: {}", e.getActionCommand());
         if (e.getActionCommand().equals("Save")) {
-            int returnVal = fc.showSaveDialog(editor);
-
-            if (returnVal == JFileChooser.APPROVE_OPTION) {
-                editor.savedFile = fc.getSelectedFile();
-                editor.saveMap(editor.loadedFile.getAbsolutePath(), editor.savedFile.getAbsolutePath());
-            }
+            editor.saveMap();
         }
         if (e.getActionCommand().equals(AutoDriveEditor.MOVE_NODES)) {
             this.editor.editorState = AutoDriveEditor.EDITORSTATE_MOVING;
@@ -54,21 +47,25 @@ public class EditorListener implements ActionListener {
         }
         editor.updateButtons();
         if (e.getActionCommand().equals("Load")) {
+            JFileChooser fc = new JFileChooser();
+            fc.setDialogTitle("Select AutoDrive Config");
+            fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
+            fc.setAcceptAllFileFilterUsed(false);
+            FileNameExtensionFilter filter = new FileNameExtensionFilter("AutoDrive config", "xml");
+            fc.addChoosableFileFilter(filter);
             int returnVal = fc.showOpenDialog(editor);
 
             if (returnVal == JFileChooser.APPROVE_OPTION) {
-                editor.loadedFile = fc.getSelectedFile();
-                try {
-                    editor.getMapPanel().setRoadMap(editor.loadFile(editor.loadedFile.getAbsolutePath()));
-                    editor.pack();
-                    editor.repaint();
-                    editor.getMapPanel().repaint();
-                } catch (ParserConfigurationException | SAXException | IOException e1) {
-                    LOG.error(e1.getMessage(), e1);
-                }
+                File fileName = fc.getSelectedFile();
+                editor.loadConfigFile(fileName);
+                editor.pack();
+                editor.repaint();
+                editor.getMapPanel().repaint();
+
             }
         }
         if (e.getActionCommand().equals("Load Image")) {
+            JFileChooser fc = new JFileChooser();
             int returnVal = fc.showOpenDialog(editor);
 
             if (returnVal == JFileChooser.APPROVE_OPTION) {

--- a/AutoDrive Course Editor/src/main/java/de/adEditor/MapPanel.java
+++ b/AutoDrive Course Editor/src/main/java/de/adEditor/MapPanel.java
@@ -197,7 +197,7 @@ public class MapPanel extends JPanel{
     public void moveNodeBy(MapNode node, int diffX, int diffY) {
         node.x +=  ((diffX * mapZoomFactor) / zoomLevel);
         node.z += ((diffY * mapZoomFactor) / zoomLevel);
-
+        editor.setStale(true);
         repaint();
     }
 
@@ -218,6 +218,7 @@ public class MapPanel extends JPanel{
 
     public void removeNode(MapNode toDelete) {
         this.roadMap.removeMapNode(toDelete);
+        editor.setStale(true);
         this.repaint();
     }
 
@@ -230,6 +231,7 @@ public class MapPanel extends JPanel{
         }
         if (destinationToDelete != null) {
             this.roadMap.removeMapMarker(destinationToDelete);
+            editor.setStale(true);
             this.repaint();
         }
     }
@@ -242,6 +244,7 @@ public class MapPanel extends JPanel{
         MapNode mapNode = new MapNode(this.roadMap.mapNodes.size()+1, screenX, -1, screenY);
 
         this.roadMap.mapNodes.add(mapNode);
+        editor.setStale(true);
         this.repaint();
     }
 
@@ -291,12 +294,14 @@ public class MapPanel extends JPanel{
             start.outgoing.remove(target);
             target.incoming.remove(start);
         }
+        editor.setStale(true);
     }
 
     public void createDestinationAt(MapNode mapNode, String destinationName) {
         if (mapNode != null && destinationName != null && destinationName.length() > 0) {
             MapMarker mapMarker = new MapMarker(mapNode, destinationName, "All");
             this.roadMap.addMapMarker(mapMarker);
+            editor.setStale(true);
         }
     }
 
@@ -325,10 +330,13 @@ public class MapPanel extends JPanel{
                 toDelete.add(mapNode);
             }
         }
-        for (MapNode node : toDelete)  {
-            roadMap.removeMapNode(node);
-        }
+        if (!toDelete.isEmpty()) {
+            editor.setStale(true);
 
+            for (MapNode node : toDelete) {
+                roadMap.removeMapNode(node);
+            }
+        }
     }
 
     public void drawArrowBetween(Graphics g, Point2D start, Point2D target, boolean dual) {


### PR DESCRIPTION
Hallo Stephan,

vor einigen Tagen gab es hier im Forum(#1097) mal den Fall, dass ein Benutzer seine Config umbenannt hatte und dabei "Autodrive" anstelle von "AutoDrive" geschrieben hatte. 
Die Folge war, dass die Config nicht mehr gefunden wurde und es gab Exceptions. 
Ich habe mir das dann angesehen und bin über den SaveDialog gestolpert. Wozu benötige ich hier einen SaveDialog? Der Workflow ist doch immer so: Datei auswähle -> editieren -> gleiche Datei speichern.
Das Umbenennen würde an dieser Stelle doch eh nix bringen. Ich habe mal im LUA-Teil geschaut - da wird doch auch immer fest AutoDrive_<KARTE>_config.xml geladen, oder?
Wenn der Benutzer unbedingt etwas umbenennen möchte, ist es wohl eher aus Backup-Gründen und ich finde das soll er mal so zu Fuß machen. Oder wir können bei jedem Speichern immer eine Historie an Dateien anlegen. Z.B. AutoDrive_Felsbrunn_config.1.xml, AutoDrive_Felsbrunn_config.2.xml, AutoDrive_Felsbrunn_config.3.xml,....

OK, also ich habe den SaveDialog mal entfernt und noch Meldungen eingebaut, wenn ein Fehler beim Speichern und Laden auftritt oder der Benutzer den Editor schließt und Änderungen sind noch nicht gespeichert. Der aktuelle Pfadname wird nun auch oben im Titel angezeit.
Schau es dir mal an...
Was hast du im Moment für weitere Ideen für den Editor ?
