### PR TITLE
Dynamic chase

### DIFF
--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -354,15 +354,14 @@ function CombineUnloaderMode:getSideChaseOffsetZ()
     -- helps the sugarcane harvester. We start at at the front of the trailer. We use an exponential
     -- to increase dwell time towards the front of the trailer, since loads migrate towards the back.
     
-    -- The constant additions should put at precisely at the joint of the vehicle and trailer, then a little futher
-    -- back so non-semis don't miss
-    local constantAdditionsZ = diffZ + pipeRootOffsetZ + self.vehicle.sizeLength/2 + 2  --+ (self.vehicle.sizeLength/2 - targetTrailer.sizeLength/2) + 2
-    --local constantAdditionsZ = diffZ + pipeRootOffsetZ  + (self.vehicle.sizeLength/2 - targetTrailer.sizeLength/2) + 2
-    -- We then gradually move back, but don't use the last two meters of trailer for cosmetic reasons
-    local dynamicAdditionsZ = math.max((targetTrailer.sizeLength - constantAdditionsZ - 2) ^ targetTrailerFillRatio, 0)
-    local sideChaseTermZ = constantAdditionsZ + dynamicAdditionsZ --- (targetTrailer.sizeLength / 2)
-    AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getSideChaseOffsetZ - " ..
-    maxOffset .. "/" .. sideChaseTermZ .. "/" ..math.min(maxOffset, sideChaseTermZ) .. "//" )
+    -- The constant additions should put at precisely at the joint of the vehicle and trailer, then correct for
+    -- only moving the midpoint of the tractor
+    local constantAdditionsZ = 1 + self.vehicle.sizeLength/2 - targetTrailer.sizeLength/2
+    -- We then gradually move back, but don't use the last part of trailer for cosmetic reasons
+    local dynamicAdditionsZ = diffZ + pipeRootOffsetZ + math.max((targetTrailer.sizeLength - self.vehicle.sizeLength/2 - 2) ^ targetTrailerFillRatio, 0)
+    local sideChaseTermZ = constantAdditionsZ + dynamicAdditionsZ
+    --AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getSideChaseOffsetZ - " ..
+    --maxOffset .. "/" .. sideChaseTermZ .. "/" ..math.min(maxOffset, sideChaseTermZ) .. "//" )
     return math.min(maxOffset, sideChaseTermZ)
 end
 

--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -301,18 +301,19 @@ function CombineUnloaderMode:getSideChaseOffsetX()
     -- NB: We cannot apply slope correction until after we have chosen which side
     -- we are chasing on! This function only finds the base X offset "to the left".
     -- Slope and side correction MUST be applied in CombineUnloaderMode:getPipeChasePosition
-    -- AFTER dertmining the chase side. Or this function needs to be rewritten.
-    -- local dischargeNode = AutoDrive.getDischargeNode(self.combine)
+    -- AFTER determining the chase side. Or this function needs to be rewritten.
     local targetTrailer, targetTrailerFillRatio = self:getTargetTrailer()
     local pipeOffset = AutoDrive.getSetting("pipeOffset", self.vehicle)
     local pipeRootOffsetX, _, _= AutoDrive.getPipeRootOffset(self.combine)
-    local unloaderWidest = math.max(self.vehicle.sizeWidth/2, targetTrailer.sizeWidth/2)
+    local unloaderWidest = math.max(self.vehicle.sizeWidth, targetTrailer.sizeWidth)
     local headerExtra = math.max((AutoDrive.getFrontToolWidth(self.combine) - self.combine.sizeWidth)/2, 
                                 0)
+    AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getSideChaseOffsetX - " ..
+    pipeRootOffsetX .. "/" .. unloaderWidest .. "/" .. headerExtra .. "/" .. AutoDrive.getPipeLength(self.combine) .. "//" )
 
     local sideChaseTermPipeIn = self.combine.sizeWidth/2 + 
                                 unloaderWidest + 
-                                headerExtra + 1
+                                headerExtra
     local sideChaseTermPipeOut = self.combine.sizeWidth/2 + 
                                     (AutoDrive.getPipeLength(self.combine) + pipeOffset)
     -- Some combines fold up their pipe so tight that targeting it could cause a collision.
@@ -320,11 +321,15 @@ function CombineUnloaderMode:getSideChaseOffsetX()
     local sideChaseTermX = math.max(sideChaseTermPipeIn, sideChaseTermPipeOut)
 
     local spec = self.combine.spec_pipe
-    if spec.currentState == spec.targetState and (spec.currentState == 2 or self.combine.typeName == "combineCutterFruitPreparer") then
+    if self.combine:getIsBufferCombine() and not AutoDrive.isSugarcaneHarvester(self.combine) then
+        -- If it is a buffer combine, use the pipe in offset regardless
+        sideChaseTermX = sideChaseTermPipeIn
+    elseif spec.currentState == spec.targetState and (spec.currentState == 2 or self.combine.typeName == "combineCutterFruitPreparer") then
         -- If the pipe is extended, though, target it regardless
         sideChaseTermX = sideChaseTermPipeOut
     end
-
+    AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getSideChaseOffsetX - " ..
+    sideChaseTermX )
     return sideChaseTermX
 end
 

--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -336,14 +336,14 @@ end
 function CombineUnloaderMode:getSideChaseOffsetZ()
     -- The default maximum will place the front of the unloader at the back of the header
     --local maxOffset = self.combine.sizeLength/2 - self.vehicle.sizeLength / 2
-    local maxOffset =AutoDrive.getTractorTrainLength(self.vehicle, true, false)
+    local maxOffset = 10000--AutoDrive.getTractorTrainLength(self.vehicle, true, false)
     local spec = self.combine.spec_pipe
-    if spec.currentState == spec.targetState and (spec.currentState == 2 or self.combine.typeName == "combineCutterFruitPreparer") then
+    --if spec.currentState == spec.targetState and (spec.currentState == 2 or self.combine.typeName == "combineCutterFruitPreparer") then
         -- If the pipe is extended, go as far forward as we like. This is a first approximation
         -- assuming the user isn't using a header which is wider than the pipe extends
         -- If the X direction collision avoidance is working, we might not need this guard?
-        maxOffset = AutoDrive.getTractorTrainLength(self.vehicle, true, false)
-    end
+        --maxOffset = AutoDrive.getTractorTrainLength(self.vehicle, true, false)
+    --end
 
     local targetTrailer, targetTrailerFillRatio = self:getTargetTrailer()
     local _, _, pipeRootOffsetZ= AutoDrive.getPipeRootOffset(self.combine)
@@ -356,11 +356,13 @@ function CombineUnloaderMode:getSideChaseOffsetZ()
     
     -- The constant additions should put at precisely at the joint of the vehicle and trailer, then a little futher
     -- back so non-semis don't miss
-    local constantAdditionsZ = diffZ + pipeRootOffsetZ + (self.vehicle.sizeLength/2) - (targetTrailer.sizeLength / 2) + 2
+    local constantAdditionsZ = diffZ + pipeRootOffsetZ + self.vehicle.sizeLength/2 + 2  --+ (self.vehicle.sizeLength/2 - targetTrailer.sizeLength/2) + 2
+    --local constantAdditionsZ = diffZ + pipeRootOffsetZ  + (self.vehicle.sizeLength/2 - targetTrailer.sizeLength/2) + 2
     -- We then gradually move back, but don't use the last two meters of trailer for cosmetic reasons
     local dynamicAdditionsZ = math.max((targetTrailer.sizeLength - constantAdditionsZ - 2) ^ targetTrailerFillRatio, 0)
     local sideChaseTermZ = constantAdditionsZ + dynamicAdditionsZ --- (targetTrailer.sizeLength / 2)
-
+    AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getSideChaseOffsetZ - " ..
+    maxOffset .. "/" .. sideChaseTermZ .. "/" ..math.min(maxOffset, sideChaseTermZ) .. "//" )
     return math.min(maxOffset, sideChaseTermZ)
 end
 

--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -387,7 +387,7 @@ function CombineUnloaderMode:getRearChaseOffsetZ()
         -- back than the pathfinder (straightening) target in PathFinderModule:startPathPlanningToPipe
         -- math.sqrt(2) gives the hypotenuse of an isosceles right trangle with side length equal to the length
         -- of the trailer 
-        rearChaseOffset = -self.combine.sizeLength/2 - AutoDrive.getTractorTrainLength(self.vehicle, false, true) * math.sqrt(2)
+        rearChaseOffset = -self.combine.sizeLength/2 - AutoDrive.getTractorTrainLength(self.vehicle, true, false) * math.sqrt(2)
     end
 
     return rearChaseOffset

--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -297,6 +297,95 @@ function CombineUnloaderMode:getTargetTrailer()
     return targetTrailer, fillRatio
 end
 
+function CombineUnloaderMode:getSideChaseOffsetX()
+    -- NB: We cannot apply slope correction until after we have chosen which side
+    -- we are chasing on! This function only finds the base X offset "to the left".
+    -- Slope and side correction MUST be applied in CombineUnloaderMode:getPipeChasePosition
+    -- AFTER dertmining the chase side. Or this function needs to be rewritten.
+    -- local dischargeNode = AutoDrive.getDischargeNode(self.combine)
+    local targetTrailer, targetTrailerFillRatio = self:getTargetTrailer()
+    local pipeOffset = AutoDrive.getSetting("pipeOffset", self.vehicle)
+    local pipeRootOffsetX, _, _= AutoDrive.getPipeRootOffset(self.combine)
+    local unloaderWidest = math.max(self.vehicle.sizeWidth/2, targetTrailer.sizeWidth/2)
+    local headerExtra = math.max((AutoDrive.getFrontToolWidth(self.combine) - self.combine.sizeWidth)/2, 
+                                0)
+
+    local sideChaseTermPipeIn = self.combine.sizeWidth/2 + 
+                                unloaderWidest + 
+                                headerExtra + 1
+    local sideChaseTermPipeOut = self.combine.sizeWidth/2 + 
+                                    (AutoDrive.getPipeLength(self.combine) + pipeOffset)
+    -- Some combines fold up their pipe so tight that targeting it could cause a collision.
+    -- So, choose the max between the two to avoid a collison
+    local sideChaseTermX = math.max(sideChaseTermPipeIn, sideChaseTermPipeOut)
+
+    local spec = self.combine.spec_pipe
+    if spec.currentState == spec.targetState and (spec.currentState == 2 or self.combine.typeName == "combineCutterFruitPreparer") then
+        -- If the pipe is extended, though, target it regardless
+        sideChaseTermX = sideChaseTermPipeOut
+    end
+
+    return sideChaseTermX
+end
+
+function CombineUnloaderMode:getSideChaseOffsetZ()
+    -- The default maximum will place the front of the unloader at the back of the header
+    --local maxOffset = self.combine.sizeLength/2 - self.vehicle.sizeLength / 2
+    local maxOffset =AutoDrive.getTractorTrainLength(self.vehicle, true, false)
+    local spec = self.combine.spec_pipe
+    if spec.currentState == spec.targetState and (spec.currentState == 2 or self.combine.typeName == "combineCutterFruitPreparer") then
+        -- If the pipe is extended, go as far forward as we like. This is a first approximation
+        -- assuming the user isn't using a header which is wider than the pipe extends
+        -- If the X direction collision avoidance is working, we might not need this guard?
+        maxOffset = AutoDrive.getTractorTrainLength(self.vehicle, true, false)
+    end
+
+    local targetTrailer, targetTrailerFillRatio = self:getTargetTrailer()
+    local _, _, pipeRootOffsetZ= AutoDrive.getPipeRootOffset(self.combine)
+    vehicleX, vehicleY, vehicleZ = getWorldTranslation(self.vehicle.components[1].node)
+    local _, _, diffZ = worldToLocal(targetTrailer.components[1].node, vehicleX, vehicleY, vehicleZ)
+    
+    -- We gradually move the chase node forward as a function of fill level because it's pretty and
+    -- helps the sugarcane harvester. We start at at the front of the trailer. We use an exponential
+    -- to increase dwell time towards the front of the trailer, since loads migrate towards the back.
+    
+    -- The constant additions should put at precisely at the joint of the vehicle and trailer, then a little futher
+    -- back so non-semis don't miss
+    local constantAdditionsZ = diffZ + pipeRootOffsetZ + (self.vehicle.sizeLength/2) - (targetTrailer.sizeLength / 2) + 2
+    -- We then gradually move back, but don't use the last two meters of trailer for cosmetic reasons
+    local dynamicAdditionsZ = math.max((targetTrailer.sizeLength - constantAdditionsZ - 2) ^ targetTrailerFillRatio, 0)
+    local sideChaseTermZ = constantAdditionsZ + dynamicAdditionsZ --- (targetTrailer.sizeLength / 2)
+
+    return math.min(maxOffset, sideChaseTermZ)
+end
+
+function CombineUnloaderMode:getRearChaseOffsetX()
+    local targetTrailer, targetTrailerFillRatio = self:getTargetTrailer()
+    local rearChaseOffset = 0
+    if self.combine.getIsBufferCombine == nil or not self.combine:getIsBufferCombine() or AutoDrive.isSugarcaneHarvester(self.combine) then
+        local pipeSide = AutoDrive.getPipeSide(self.combine)
+        rearChaseOffset = -pipeSide*(self.combine.sizeWidth/2 + math.max(self.vehicle.sizeWidth, targetTrailer.sizeWidth)/2)+1
+    end
+
+    return rearChaseOffset
+end
+
+function CombineUnloaderMode:getRearChaseOffsetZ()
+    local followDistance = AutoDrive.getSetting("followDistance", self.vehicle)
+    local rearChaseOffset = -followDistance - (self.combine.sizeLength / 2)
+    if self.combine.getIsBufferCombine ~= nil and self.combine:getIsBufferCombine() and not AutoDrive.isSugarcaneHarvester(self.combine) then
+        rearChaseOffset = -followDistance - (self.combine.sizeLength / 2)
+    else
+        -- math.sqrt(2) ensures the trailer could straighten if it was turned 90 degrees, and it makes this point further
+        -- back than the pathfinder (straightening) target in PathFinderModule:startPathPlanningToPipe
+        -- math.sqrt(2) gives the hypotenuse of an isosceles right trangle with side length equal to the length
+        -- of the trailer 
+        rearChaseOffset = -self.combine.sizeLength/2 - AutoDrive.getTractorTrainLength(self.vehicle, false, true) * math.sqrt(2)
+    end
+
+    return rearChaseOffset
+end
+
 function CombineUnloaderMode:getPipeChasePosition()
     local worldX, worldY, worldZ = getWorldTranslation(self.combine.components[1].node)
     local vehicleX, _, vehicleZ = getWorldTranslation(self.vehicle.components[1].node)
@@ -325,36 +414,26 @@ function CombineUnloaderMode:getPipeChasePosition()
         end
     end
 
-    local targetTrailer, targetTrailerFillRatio = self:getTargetTrailer()
     local dischargeNode = AutoDrive.getDischargeNode(self.combine)
     local pipeSide = AutoDrive.getPipeSide(self.combine)
     -- Slope correction is a very fickle thing for buffer harvesters since you can't know
     -- whether the pipe will be on the same side as the chase.
-    --local slopeCorrection = self:getPipeSlopeCorrection(self.combine.components[1].node, dischargeNode.node)
     local slopeCorrection = self:getPipeSlopeCorrection()
-    local pipeOffset = AutoDrive.getSetting("pipeOffset", self.vehicle)
-    local followDistance = AutoDrive.getSetting("followDistance", self.vehicle)
-    local sideChaseTermX = math.max(targetTrailer.sizeWidth/2, self.vehicle.sizeWidth/2) + AutoDrive.getPipeLength(self.combine) + pipeOffset
+
+    local sideChaseTermX = self:getSideChaseOffsetX()
+    local sideChaseTermZ = self:getSideChaseOffsetZ()
+    local rearChaseTermX = self:getRearChaseOffsetX()
+    local rearChaseTermZ = self:getRearChaseOffsetZ()
     
-    local trailerX, trailerY, trailerZ = getWorldTranslation(targetTrailer.components[1].node)
-    local _, _, diffZ = worldToLocal(self.vehicle.components[1].node, trailerX, trailerY, trailerZ)
-    -- We gradually move the chose node forward as a function of fill level to more efftively fill
-    -- buffer combines. We start ot at the front of the trailer +4 units. We use an exponential
-    -- to increase dwell time towards the front of the trailer, since loads migrate towards the back.
-    local _, _, pipeRootOffsetZ= AutoDrive.getPipeRootOffset(self.combine)
-    local ZConstantAdditions = pipeRootOffsetZ + 2
-    local sideChaseTermZ = -diffZ + ZConstantAdditions + (targetTrailer.sizeLength - 1 - ZConstantAdditions) ^ targetTrailerFillRatio - (targetTrailer.sizeLength / 2)
-    --AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getPipeChasePosition - " .. 
-    --slopeCorrection .. " " .. AutoDrive.getSetting("pipeOffset", self.vehicle) .. " " .. pipeOffset .. " " .. sideChaseTermX*pipeSide ..
-    --" " .. sideChaseTermZ)
     if self.combine.getIsBufferCombine ~= nil and self.combine:getIsBufferCombine() then
         AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getPipeChasePosition=IsBufferCombine")
-        if not AutoDrive.isSugarcaneHarvester(self.combine) then
-            sideChaseTermZ = -followDistance - (self.combine.sizeLength / 2)
-        end
+        --if not AutoDrive.isSugarcaneHarvester(self.combine) then
+        --    sideChaseTermZ = sideChaseTermZ - dynamicAdditionsZ
+        --end
+        
         local leftChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, sideChaseTermX  + slopeCorrection, sideChaseTermZ)
         local rightChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, -sideChaseTermX  + slopeCorrection, sideChaseTermZ)
-        local rearChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, 0, -followDistance - (self.combine.sizeLength / 2))
+        local rearChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, 0, rearChaseTermZ)
         local angleToLeftChaseSide = self:getAngleToChasePos(leftChasePos)
         local angleToRearChaseSide = self:getAngleToChasePos(rearChasePos)
         
@@ -399,9 +478,10 @@ function CombineUnloaderMode:getPipeChasePosition()
             sideIndex = AutoDrive.CHASEPOS_REAR
             -- We chase off to the side to avoid collisions
             -- We chase a little further back to avoid eating dust
-            chaseNode = AutoDrive.createWayPointRelativeToVehicle(self.combine, 
-                                                                    -pipeSide*(self.combine.sizeWidth/2 + math.max(self.vehicle.sizeWidth, targetTrailer.sizeWidth)/2)+1,
-                                                                    -self.combine.sizeLength/2 - AutoDrive.getTractorTrainLength(self.vehicle, false, true) * math.sqrt(2))
+            --chaseNode = AutoDrive.createWayPointRelativeToVehicle(self.combine, 
+            --                                                        -pipeSide*(self.combine.sizeWidth/2 + math.max(self.vehicle.sizeWidth, targetTrailer.sizeWidth)/2)+1,
+            --                                                        -self.combine.sizeLength/2 - AutoDrive.getTractorTrainLength(self.vehicle, false, true) * math.sqrt(2))
+            chaseNode = AutoDrive.createWayPointRelativeToVehicle(self.combine, rearChaseTermX, rearChaseTermZ)
         end
     end
 

--- a/FS19_AutoDrive/scripts/Modules/PathFinderModule.lua
+++ b/FS19_AutoDrive/scripts/Modules/PathFinderModule.lua
@@ -87,7 +87,7 @@ function PathFinderModule:startPathPlanningToPipe(combine, chasing)
     -- the trailer. Add an extra follow distance because the unloader stops well before the back
     -- of the trailer.
     --local lengthOffset = combine.sizeLength/2 + AutoDrive.getTractorTrainLength(self.vehicle, false, true) * math.sqrt(2)
-    local lengthOffset = combine.sizeLength/2 + AutoDrive.getTractorTrainLength(self.vehicle, false, true) * (2*math.sin(math.pi/8))
+    local lengthOffset = combine.sizeLength/2 + AutoDrive.getTractorTrainLength(self.vehicle, true, false) * (2*math.sin(math.pi/8))
     -- A bit of a sanity check, in case the vehicle is absurdly long.
     --if lengthOffset > self.PATHFINDER_FOLLOW_DISTANCE then
     --    lengthOffset = self.PATHFINDER_FOLLOW_DISTANCE 

--- a/FS19_AutoDrive/scripts/Tasks/EmptyHarvesterTask.lua
+++ b/FS19_AutoDrive/scripts/Tasks/EmptyHarvesterTask.lua
@@ -57,13 +57,12 @@ function EmptyHarvesterTask:update(dt)
         if self.vehicle.ad.drivePathModule:isTargetReached() then
             AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "EmptyHarvesterTask:update - next: EmptyHarvesterTask.STATE_UNLOADING 1")
             self.state = EmptyHarvesterTask.STATE_UNLOADING
-        else
-            if self.combine.getDischargeState ~= nil and self.combine:getDischargeState() ~= Dischargeable.DISCHARGE_STATE_OFF then
+        elseif (AutoDrive.getSetting("preCallLevel", self.combine) > 50 and
+                self.combine.getDischargeState ~= nil and self.combine:getDischargeState() ~= Dischargeable.DISCHARGE_STATE_OFF) then
                 AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "EmptyHarvesterTask:update - next: EmptyHarvesterTask.STATE_UNLOADING 2")
                 self.state = EmptyHarvesterTask.STATE_UNLOADING
-            else
-                self.vehicle.ad.drivePathModule:update(dt)
-            end
+        else
+            self.vehicle.ad.drivePathModule:update(dt)
         end
         local trailers, _ = AutoDrive.getTrailersOf(self.vehicle, false)
         AutoDrive.setTrailerCoverOpen(self.vehicle, trailers, true)

--- a/FS19_AutoDrive/scripts/Tasks/FollowCombineTask.lua
+++ b/FS19_AutoDrive/scripts/Tasks/FollowCombineTask.lua
@@ -18,18 +18,19 @@ function FollowCombineTask:new(vehicle, combine)
     o.angleWrongTimer = AutoDriveTON:new()
     o.waitForTurnTimer = AutoDriveTON:new()
     o.stuckTimer = AutoDriveTON:new()
-    o.caughtCurrentChaseSide = false
     o.lastChaseSide = -10
     o.waitForPassByTimer = AutoDriveTON:new()
     o.chaseTimer = AutoDriveTON:new()
     o.startedChasing = false
     o.reverseTimer = AutoDriveTON:new()
+    o.chasePos, o.chaseSide = vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getPipeChasePosition()
+    o.angleToCombineHeading = vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getAngleToCombineHeading()
+    o.angleToCombine = vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getAngleToCombine()
     return o
 end
 
 function FollowCombineTask:setUp()
     AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "Setting up FollowCombineTask")
-    _, self.chaseSide = self.vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getPipeChasePosition()
     self.lastChaseSide = self.chaseSide
 end
 
@@ -73,6 +74,7 @@ function FollowCombineTask:update(dt)
         if (AutoDrive.combineIsTurning(self.combine) and (self.angleToCombineHeading > 60 or not self.combine:getIsBufferCombine() or not self.combine.ad.sensors.frontSensorFruit:pollInfo())) or self.angleWrongTimer.elapsedTime > 10000 then
             self.state = FollowCombineTask.STATE_WAIT_FOR_TURN
             self.angleWrongTimer:timer(false)
+            self.stuckTimer:timer(false)
         elseif ((self.combine.lastSpeedReal * self.combine.movingDirection) <= -0.00005) then
             self.vehicle.ad.specialDrivingModule:driveReverse(dt, self.combine.lastSpeedReal * 3600 * 1.3, 1)
         else
@@ -83,7 +85,6 @@ function FollowCombineTask:update(dt)
         AutoDrive.setTrailerCoverOpen(self.vehicle, trailers, true)
     elseif self.state == FollowCombineTask.STATE_WAIT_FOR_TURN then
         self.waitForTurnTimer:timer(true, 60000, dt)
-        self.caughtCurrentChaseSide = self:isCaughtCurrentChaseSide()
         if self.waitForTurnTimer:done() then
             self.waitForTurnTimer:timer(false)
             self:finished()
@@ -97,6 +98,7 @@ function FollowCombineTask:update(dt)
         if not AutoDrive.combineIsTurning(self.combine) and self.combine.ad.sensors.frontSensorFruit:pollInfo() then
             if (self.angleToCombineHeading + self.angleToCombine) < 180 then
                 self.state = FollowCombineTask.STATE_CHASING
+                self.waitForTurnTimer:timer(false)
                 self.chaseTimer:timer(false)
             else
                 self.stayOnField = true
@@ -111,7 +113,6 @@ function FollowCombineTask:update(dt)
         self.waitForPassByTimer:timer(true, 2200, dt)
         self.vehicle.ad.specialDrivingModule:stopVehicle()
         self.vehicle.ad.specialDrivingModule:update(dt)
-        self.caughtCurrentChaseSide = self:isCaughtCurrentChaseSide()
         if self.waitForPassByTimer:done() then
             self.waitForPassByTimer:timer(false)
             self.chaseTimer:timer(false)
@@ -140,10 +141,10 @@ end
 function FollowCombineTask:updateStates()
     local x, y, z = getWorldTranslation(self.vehicle.components[1].node)
     local cx, cy, cz = getWorldTranslation(self.combine.components[1].node)
+    self.chasePos, self.chaseSide = self.vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getPipeChasePosition()
     self.angleToCombineHeading = self.vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getAngleToCombineHeading()
     self.angleToCombine = self.vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getAngleToCombine()
 
-    self.chasePos, self.chaseSide = self.vehicle.ad.modes[AutoDrive.MODE_UNLOAD]:getPipeChasePosition()
     if self.chaseSide ~= self.lastChaseSide then
         if AutoDrive.isSugarcaneHarvester(self.combine) then
             self.reverseStartLocation = {x = x, y = y, z = z}
@@ -152,7 +153,6 @@ function FollowCombineTask:updateStates()
         --if self.lastChaseSide ~= CombineUnloaderMode.CHASEPOS_REAR then
             self.state = FollowCombineTask.STATE_WAIT_FOR_PASS_BY
         end
-        self.caughtCurrentChaseSide = false
         self.lastChaseSide = self.chaseSide
     end
     -- If we haven't caught up with the current chaseSide, we put the target ahead of it, so the unloader will get much closer to the combine for these changes and won't cause the combine to stop due to the pipe distance
@@ -197,7 +197,6 @@ end
 function FollowCombineTask:shouldWaitForChasePos(dt)
     local angle = self:getAngleToChasePos(dt)
     self.angleWrongTimer:timer(angle > 50, 3000, dt)
-    self.caughtCurrentChaseSide = self:isCaughtCurrentChaseSide()
     local _, _, diffZ = worldToLocal(self.vehicle.components[1].node, self.chasePos.x, self.chasePos.y, self.chasePos.z)
     return self.angleWrongTimer:done() or  diffZ <= -1 --or (not self.combine.ad.sensors.frontSensorFruit:pollInfo())
 end
@@ -249,7 +248,7 @@ function FollowCombineTask:getInfoText()
     local text = ""
     if self.state == FollowCombineTask.STATE_CHASING then
         text = g_i18n:getText("AD_task_chasing_combine") .. "-"
-        if not self.caughtCurrentChaseSide then
+        if not self:isCaughtCurrentChaseSide() then
             text = text .. g_i18n:getText("AD_task_catching_chase_side") .. ": "
         else
             text = text .. g_i18n:getText("AD_task_chase_side") .. ": "
@@ -275,7 +274,7 @@ function FollowCombineTask:getI18nInfo()
     local text = ""
     if self.state == FollowCombineTask.STATE_CHASING then
         text = "$l10n_AD_task_chasing_combine;" .. "-"
-        if not self.caughtCurrentChaseSide then
+        if not self:isCaughtCurrentChaseSide() then
             text = text .. "$l10n_AD_task_catching_chase_side;" .. ": "
         else
             text = text .. "$l10n_AD_task_chase_side;" .. ": "

--- a/FS19_AutoDrive/scripts/Utils/Buffer.lua
+++ b/FS19_AutoDrive/scripts/Utils/Buffer.lua
@@ -28,6 +28,12 @@ function Buffer:Get()
     end
 end
 
+function Buffer:Peek()
+    if self:Count() > 0 then
+        return self.items[table.maxn(self.items)]
+    end
+end
+
 function Buffer:Clear()
     self.items = {}
     self.itemsCount = 0

--- a/FS19_AutoDrive/scripts/Utils/CombineUtil.lua
+++ b/FS19_AutoDrive/scripts/Utils/CombineUtil.lua
@@ -46,15 +46,15 @@ function AutoDrive.getPipeRoot(combine)
             pipeRootAgl = pipeRootWorldY - heightUnderRoot
             translationMagnitude = MathUtil.vector3Length(pipeRootX, pipeRootY, pipeRootZ)
         end
-        AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. pipeRoot .. " " .. AutoDrive.getNodeName(pipeRoot))
-        AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX) .. " " .. AutoDrive.getPipeSide(combine))
+        --AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. pipeRoot .. " " .. AutoDrive.getNodeName(pipeRoot))
+        --AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX) .. " " .. AutoDrive.getPipeSide(combine))
     until ((translationMagnitude > 0.01 and translationMagnitude < 100) and
            (combine:getIsBufferCombine() or AutoDrive.sign(pipeRootX) == AutoDrive.getPipeSide(combine)) and
            (pipeRootY > 0) or
            parentStack:Count() == 0
           )
-    AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. pipeRoot .. " " .. AutoDrive.getNodeName(pipeRoot))
-    AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX)  .. " ".. AutoDrive.getPipeSide(combine))
+    AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Pipe Root " .. pipeRoot .. " " .. AutoDrive.getNodeName(pipeRoot))
+    AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Pipe Root " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX)  .. " ".. AutoDrive.getPipeSide(combine))
      
     if pipeRoot == nil or pipeRoot == 0 then
         pipeRoot = combine.components[1].node
@@ -113,7 +113,7 @@ function AutoDrive.getFrontToolWidth(vehicle)
                 local toolX, toolY, toolZ = getWorldTranslation(tool.components[1].node)
                 local _, _, offsetZ =  worldToLocal(vehicle.components[1].node, toolX, toolY, toolZ)
                 if offsetZ > 0 then
-                    widthOfFrontTool = math.max(widthOfFrontTool, tool.sizeLength)
+                    widthOfFrontTool = math.abs(tool.sizeWidth)
                 end
             end
         end

--- a/FS19_AutoDrive/scripts/Utils/CombineUtil.lua
+++ b/FS19_AutoDrive/scripts/Utils/CombineUtil.lua
@@ -101,3 +101,23 @@ function AutoDrive.isSugarcaneHarvester(combine)
     end
     return isSugarCaneHarvester
 end
+
+function AutoDrive.getFrontToolWidth(vehicle)
+    local widthOfFrontTool = 0
+
+    if vehicle.getAttachedImplements ~= nil then
+        for _, impl in pairs(vehicle:getAttachedImplements()) do
+            local tool = impl.object
+            if tool ~= nil and tool.sizeWidth ~= nil then
+                --Check if tool is in front of vehicle
+                local toolX, toolY, toolZ = getWorldTranslation(tool.components[1].node)
+                local _, _, offsetZ =  worldToLocal(vehicle.components[1].node, toolX, toolY, toolZ)
+                if offsetZ > 0 then
+                    widthOfFrontTool = math.max(widthOfFrontTool, tool.sizeLength)
+                end
+            end
+        end
+    end
+
+    return widthOfFrontTool
+end

--- a/FS19_AutoDrive/scripts/Utils/CombineUtil.lua
+++ b/FS19_AutoDrive/scripts/Utils/CombineUtil.lua
@@ -2,6 +2,14 @@ AutoDrive.CHASEPOS_LEFT = 1
 AutoDrive.CHASEPOS_RIGHT = -1
 AutoDrive.CHASEPOS_REAR = 3
 
+function AutoDrive.getNodeName(node)
+    if node == nil then
+        return "nil"
+    else
+        return getName(node)
+    end
+end
+
 function AutoDrive.getDischargeNode(combine)
     local dischargeNode = nil
     for _, dischargeNodeIter in pairs(combine.spec_dischargeable.dischargeNodes) do
@@ -14,48 +22,42 @@ function AutoDrive.getDischargeNode(combine)
 end
 
 function AutoDrive.getPipeRoot(combine)
-    local count = 0
     local pipeRoot = AutoDrive.getDischargeNode(combine)
     local parentStack = Buffer:new()
     local combineNode = combine.components[1].node
-    --AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Combine Node " .. combineNode .. " " .. self:getNodeName(combineNode))
-    
-    while (pipeRoot ~= combineNode) and (count < 100) and (pipeRoot ~= nil) do
+
+    repeat
         parentStack:Insert(pipeRoot)
         pipeRoot = getParent(pipeRoot)
-        if pipeRoot == 0 or pipeRoot == nil then
-            -- Something unexpected happened, like the discharge node not belonging to self.combine.
-            -- This can happen with harvesters with multiple components
-            -- KNOWN ISSUE: The Panther 2 beet harvester triggers this condition
-            return combineNode
-        end
-        count = count + 1
-    end
+    until ((pipeRoot == combineNode) or (pipeRoot == 0) or (pipeRoot == nil) or parentStack:Count() == 100)
 
     local translationMagnitude = 0
-    -- Pop the first thing off the stack. This should refer to a large chunk of the harvester and it useless
-    -- for our purposes.
-    --parentStack:Get()
-    pipeRoot = parentStack:Get()
-    local pipeRootX, pipeRootY, pipeRootZ = getTranslation(pipeRoot)
-    local pipeRootWorldX, pipeRootWorldY, pipeRootWorldZ = getWorldTranslation(pipeRoot)
-    local heightUnderRoot = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, pipeRootWorldX, pipeRootWorldY, pipeRootWorldZ)
-    local pipeRootAgl = pipeRootWorldY - heightUnderRoot
-    --AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeTranslationRoot - Search Stack " .. pipeRoot .. " " .. self:getNodeName(pipeRoot))
-    --AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeTranslationRoot - Search Stack " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX))
-    while ((translationMagnitude < 0.01) or 
-            (not combine:getIsBufferCombine() and AutoDrive.sign(pipeRootX) ~= AutoDrive.getPipeSide(combine)) or
-            (pipeRootY < 0) and -- This may be a poor assumption. Depends on where the "moving parts" node is translated to, and it's inconsistent.
-            parentStack:Count() > 0) do
+    local pipeRootX, pipeRootY, pipeRootZ
+    local pipeRootWorldX, pipeRootWorldY, pipeRootWorldZ
+    local heightUnderRoot, pipeRootAgl
+    local lastPipeRoot = pipeRoot
+
+    repeat
         pipeRoot = parentStack:Get()
-        pipeRootX, pipeRootY, pipeRootZ = getTranslation(pipeRoot)
-        pipeRootWorldX, pipeRootWorldY, pipeRootWorldZ = getWorldTranslation(pipeRoot)
-        heightUnderRoot = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, pipeRootWorldX, pipeRootWorldY, pipeRootWorldZ)
-        pipeRootAgl = pipeRootWorldY - heightUnderRoot
-        
-        translationMagnitude = MathUtil.vector3Length(pipeRootX, pipeRootY, pipeRootZ)
-        --AutoDrive.debugPrint(self.combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeTranslationRoot - Search Stack " .. pipeRoot .. " " .. self:getNodeName(pipeRoot))
-        --AutoDrive.debugPrint(self.combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeTranslationRoot - Search Stack " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX))
+        if pipeRoot ~= nil and pipeRoot ~= 0 then
+            pipeRootX, pipeRootY, pipeRootZ = getTranslation(pipeRoot)
+            pipeRootWorldX, pipeRootWorldY, pipeRootWorldZ = getWorldTranslation(pipeRoot)
+            heightUnderRoot = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, pipeRootWorldX, pipeRootWorldY, pipeRootWorldZ)
+            pipeRootAgl = pipeRootWorldY - heightUnderRoot
+            translationMagnitude = MathUtil.vector3Length(pipeRootX, pipeRootY, pipeRootZ)
+        end
+        AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. pipeRoot .. " " .. AutoDrive.getNodeName(pipeRoot))
+        AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX) .. " " .. AutoDrive.getPipeSide(combine))
+    until ((translationMagnitude > 0.01 and translationMagnitude < 100) and
+           (combine:getIsBufferCombine() or AutoDrive.sign(pipeRootX) == AutoDrive.getPipeSide(combine)) and
+           (pipeRootY > 0) or
+           parentStack:Count() == 0
+          )
+    AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. pipeRoot .. " " .. AutoDrive.getNodeName(pipeRoot))
+    AutoDrive.debugPrint(combine, AutoDrive.DC_COMBINEINFO, "AutoDrive.getPipeRoot - Search Stack " .. translationMagnitude .. " " .. pipeRootAgl .. " " .. " " .. AutoDrive.sign(pipeRootX)  .. " ".. AutoDrive.getPipeSide(combine))
+     
+    if pipeRoot == nil or pipeRoot == 0 then
+        pipeRoot = combine.components[1].node
     end
 
     return pipeRoot

--- a/FS19_AutoDrive/scripts/Utils/UtilFuncs.lua
+++ b/FS19_AutoDrive/scripts/Utils/UtilFuncs.lua
@@ -617,7 +617,7 @@ Sprayer.registerOverwrittenFunctions =
 			"getIsAIActive",
 			function(self, superFunc)
 				local rootVehicle = self:getRootVehicle()
-				if nil ~= rootVehicle and rootVehicle.ad ~= nil and rootVehicle.ad.stateModule:isActive() and self ~= rootVehicle then
+				if nil ~= rootVehicle and rootVehicle.ad ~= nil and rootVehicle.ad.stateModule ~= nil and rootVehicle.ad.stateModule:isActive() and self ~= rootVehicle then
 					return false -- "Hackish" work-around, in attempt at convincing Sprayer.LUA to NOT turn on
 				end
 				return superFunc(self)


### PR DESCRIPTION
**Change Log**

* Fixes a sign issue from my previous PR
* Resolves collisions with some harvesters when using the dynamic Z offset for chase unloading
  - Uses the dynamic Z when "aggressively precalling" -- e.g. precall level is 50% or lower for testing. Suggest this feature be gated by its own setting.
* Makes the side chase wave back and forth less as harvesters extend and retract their pipe
* Significantly improves pipe root finding, and therefore pipe length estimation.

Stretch goal for this PR: Default pipe offset can be 0m for all harvesters.

**Known Issues**

* When the unloader transfers from the rear chase position to the side chase position it can collide with the harvester.
  * Potential fix: When changing chase positions, end the task and reverse or clear crop. I'm going to leave this one alone for now.
* Some harvesters still do not get the correct pipe length.

**Test Results**

- [x] Grain Harvester (Left handed harvesting)
- [x] Beet Harvester (Narrow left handed harvesting)
- [x] Forage Harvester
- [x] Potato Harvester (narrow right handed harvesting)
- [x] Sugarcane harvester
- [x] Multiple trailers