### PR TITLE
Rework of Slope Correction

### DIFF
--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -563,10 +563,6 @@ function CombineUnloaderMode:getPipeChasePosition()
     leftBlocked = leftBlocked or leftFrontBlocked
 
     self.pipeSide = AutoDrive.getPipeSide(self.combine)
-    -- Slope correction is a very fickle thing for buffer harvesters since you can't know
-    -- whether the pipe will be on the same side as the chase.
-    local slopeCorrection = self:getPipeSlopeCorrection()
-
     self.targetTrailer, self.targetTrailerFillRatio = self:getTargetTrailer()
     local sideChaseTermX = self:getSideChaseOffsetX()
     local sideChaseTermZ = self:getSideChaseOffsetZ(AutoDrive.experimentalFeatures.dynamicChaseDistance or not self.combine:getIsBufferCombine())

--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -370,80 +370,32 @@ end
 
 function CombineUnloaderMode:getPipeSlopeCorrection2()
     self.combineNode = self.combine.components[1].node
-    --self.unloaderNode = self.vehicle.components[1].node
-    --local combineRx, _, combineRz = localDirectionToWorld(self.combine.components[1].node, 0, 0, 1)
-    --local rx, _, rz = localDirectionToWorld(self.vehicle.components[1].node, 0, 0, 1)
-    --self.combineX, self.combineY, self.combineZ = getWorldTranslation(self.combineNode)
-    --if self.pipeSide == nil then
-    --    self.pipeSide = MathUtil.sign(AutoDrive.getPipeSide(self.combine))
-    --end
-
-    local unloaderX, unloaderY, unloaderZ = getWorldTranslation(AutoDrive.getDischargeNode(self.combine))
-    local diffX, diffY, _ = worldToLocal(self.combineNode, unloaderX, unloaderY, unloaderZ)
-    
-    --local heightUnderCombine = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, self.combineX, self.combineY, self.combineZ)
     local dischargeX, dichargeY, dischargeZ = getWorldTranslation(AutoDrive.getDischargeNode(self.combine))
-    local heightUnderPipe = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, dischargeX, dichargeY, dischargeZ)
-    --local ux, uy, _ = localDirectionToWorld(self.combineNode, 0, 1, 0)
-    --local ux, uy, _ = localDirectionToWorld(self.combineNode, 0, MathUtil.sign(self.pipeSide), 0)
-    --local wux, wuy, wuz = getTerrainNormalAtWorldPos(g_currentMission.terrainRootNode, self.combineX, self.combineY, self.combineZ)
-    --local ux, uy, uz = worldDirectionToLocal(self.unloaderNode, wux, wuy, wuz)
-    --local angleBetween = math.abs(AutoDrive.angleBetween({x = rx, z = rz}, {x = combineRx, z = combineRz}))
-    --if angleBetween > 10 then
-    --local combineX, combineY, combineZ = getWorldTranslation(self.combineNode)
-    -- This will result in corrections close to, but not quite, zero
-    --ux, uy, uz = worldDirectionToLocal(self.combineNode, wux, wuy, wuz)
-    -- It would be nice if we could use the discharge node direction and the terrain under the harveser, 
-    -- but discharge node relative rotations are untrustworthy.
-    wux, wuy, wuz = getTerrainNormalAtWorldPos(g_currentMission.terrainRootNode, dischargeX, dichargeY-heightUnderPipe, dischargeZ)
-    ux, uy, uz = worldDirectionToLocal(self.combineNode, wux, wuy, wuz)
-    diffX, diffY, _ = worldToLocal(self.combineNode, dischargeX, dichargeY, dischargeZ)
-    --diffY = dichargeY - heightUnderPipe
-    --diffX, diffY, _ = worldToLocal(AutoDrive.getDischargeNode(self.combine), combineX, combineY, combineZ)
-    --end
-
+    local diffX, diffY, _ = worldToLocal(self.combineNode, dischargeX, dichargeY, dischargeZ)
     if math.abs(diffX) < self.combine.sizeWidth/2 then
         -- Some pipes curl up so tight they cause a collisions.
         -- We just don't try to correct in this case.
         return 0
     end
-    --uy = uy * MathUtil.sign(self.pipeSide)
-    --local dx, dy, _ = localDirectionToWorld(self.combineNode, 0, 0, 1)
-    --local theta = math.atan2(uy, ux) - math.pi/2
+
+    local heightUnderPipe = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, dischargeX, dichargeY, dischargeZ)
+    -- It would be nice if we could use the discharge node direction and the terrain under the harveser, 
+    -- but discharge node rotations are untrustworthy.
+    wux, wuy, wuz = getTerrainNormalAtWorldPos(g_currentMission.terrainRootNode, dischargeX, dichargeY-heightUnderPipe, dischargeZ)
+    ux, uy, uz = worldDirectionToLocal(self.combineNode, wux, wuy, wuz)
+
     -- This is backwards from the usual order of these variables, but I need deviation from 0 and pi, not 
-    -- pi/2 and 3pi/4, so I adjust the coordinate system
-    --ux, uy = -ux, -uy
+    -- pi/2 and 3pi/4, so we adjust the coordinate system
     local theta = math.atan(ux/uy)
-    --local theta = math.atan2(ux, uy)
-    --local pipeDisplacement = (AutoDrive.getPipeLength(self.combine) + self.combine.sizeWidth / 2) * self.pipeSide
 
     local pipePosition = diffX * math.cos(theta) + diffY * math.sin(theta)
-    --local pipePosition = diffX * uy + diffY * ux
-    --local pipePosition = diffX * ux + diffY * uy
-    --local pipePosition = -pipeDisplacement * math.sin(theta) + (nodeY - self.combineY) * math.cos(theta)
     local currentElevationCorrection = pipePosition - diffX
 
-    AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getPipeSlopeCorrection2:Normal   " ..
-    ux .. "/" ..
-    uy .. "/" .. 
-    uz .. "/" ..
-    "//")
-    AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getPipeSlopeCorrection2 - " ..
-    math.deg(theta) .. "/" ..
-    diffX  .. "/" ..
-    pipePosition  .. "/" ..
-    currentElevationCorrection  .. 
-    "//")
     if math.abs(currentElevationCorrection) > 1 then
         -- Assume something has gone very wrong if the correction gets too large.
         return 0
     end
-    --local elevationCorrection = currentElevationCorrection
-    --if self.lastSlopeCorrection ~= nil then
-    --    elevationCorrection = (self.lastSlopeCorrection + currentElevationCorrection)/2
-    --end
 
-    --self.lastSlopeCorrection = currentElevationCorrection
     return currentElevationCorrection
 end
 

--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -370,30 +370,37 @@ end
 
 function CombineUnloaderMode:getPipeSlopeCorrection2()
     self.combineNode = self.combine.components[1].node
-    self.unloaderNode = self.vehicle.components[1].node
-    local combineRx, _, combineRz = localDirectionToWorld(self.combine.components[1].node, 0, 0, 1)
-    local rx, _, rz = localDirectionToWorld(self.vehicle.components[1].node, 0, 0, 1)
-    self.combineX, self.combineY, self.combineZ = getWorldTranslation(self.combineNode)
-    if self.pipeSide == nil then
-        self.pipeSide = MathUtil.sign(AutoDrive.getPipeSide(self.combine))
-    end
+    --self.unloaderNode = self.vehicle.components[1].node
+    --local combineRx, _, combineRz = localDirectionToWorld(self.combine.components[1].node, 0, 0, 1)
+    --local rx, _, rz = localDirectionToWorld(self.vehicle.components[1].node, 0, 0, 1)
+    --self.combineX, self.combineY, self.combineZ = getWorldTranslation(self.combineNode)
+    --if self.pipeSide == nil then
+    --    self.pipeSide = MathUtil.sign(AutoDrive.getPipeSide(self.combine))
+    --end
 
     local unloaderX, unloaderY, unloaderZ = getWorldTranslation(AutoDrive.getDischargeNode(self.combine))
     local diffX, diffY, _ = worldToLocal(self.combineNode, unloaderX, unloaderY, unloaderZ)
     
     --local heightUnderCombine = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, self.combineX, self.combineY, self.combineZ)
-    --local heightUnderPipe = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, nodeX, nodeY, nodeZ)
+    local dischargeX, dichargeY, dischargeZ = getWorldTranslation(AutoDrive.getDischargeNode(self.combine))
+    local heightUnderPipe = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, dischargeX, dichargeY, dischargeZ)
     --local ux, uy, _ = localDirectionToWorld(self.combineNode, 0, 1, 0)
     --local ux, uy, _ = localDirectionToWorld(self.combineNode, 0, MathUtil.sign(self.pipeSide), 0)
-    local wux, wuy, wuz = getTerrainNormalAtWorldPos(g_currentMission.terrainRootNode, self.combineX, self.combineY, self.combineZ)
-    local ux, uy, uz = worldDirectionToLocal(self.unloaderNode, wux, wuy, wuz)
-    local angleBetween = math.abs(AutoDrive.angleBetween({x = rx, z = rz}, {x = combineRx, z = combineRz}))
-    if angleBetween > 10 then
-        local dischargeX, dichargeY, dischargeZ = getWorldTranslation(AutoDrive.getDischargeNode(self.combine))
-        -- This will result in corrections close to, but not quite, zero
-        ux, uy, uz = worldDirectionToLocal(self.combineNode, wux, wuy, wuz)
-        diffX, diffY, _ = worldToLocal(self.combineNode, dischargeX, dichargeY, dischargeZ)
-    end
+    --local wux, wuy, wuz = getTerrainNormalAtWorldPos(g_currentMission.terrainRootNode, self.combineX, self.combineY, self.combineZ)
+    --local ux, uy, uz = worldDirectionToLocal(self.unloaderNode, wux, wuy, wuz)
+    --local angleBetween = math.abs(AutoDrive.angleBetween({x = rx, z = rz}, {x = combineRx, z = combineRz}))
+    --if angleBetween > 10 then
+    --local combineX, combineY, combineZ = getWorldTranslation(self.combineNode)
+    -- This will result in corrections close to, but not quite, zero
+    --ux, uy, uz = worldDirectionToLocal(self.combineNode, wux, wuy, wuz)
+    -- It would be nice if we could use the discharge node direction and the terrain under the harveser, 
+    -- but discharge node relative rotations are untrustworthy.
+    wux, wuy, wuz = getTerrainNormalAtWorldPos(g_currentMission.terrainRootNode, dischargeX, dichargeY-heightUnderPipe, dischargeZ)
+    ux, uy, uz = worldDirectionToLocal(self.combineNode, wux, wuy, wuz)
+    diffX, diffY, _ = worldToLocal(self.combineNode, dischargeX, dichargeY, dischargeZ)
+    --diffY = dichargeY - heightUnderPipe
+    --diffX, diffY, _ = worldToLocal(AutoDrive.getDischargeNode(self.combine), combineX, combineY, combineZ)
+    --end
 
     if math.abs(diffX) < self.combine.sizeWidth/2 then
         -- Some pipes curl up so tight they cause a collisions.
@@ -405,6 +412,7 @@ function CombineUnloaderMode:getPipeSlopeCorrection2()
     --local theta = math.atan2(uy, ux) - math.pi/2
     -- This is backwards from the usual order of these variables, but I need deviation from 0 and pi, not 
     -- pi/2 and 3pi/4, so I adjust the coordinate system
+    --ux, uy = -ux, -uy
     local theta = math.atan(ux/uy)
     --local theta = math.atan2(ux, uy)
     --local pipeDisplacement = (AutoDrive.getPipeLength(self.combine) + self.combine.sizeWidth / 2) * self.pipeSide
@@ -414,7 +422,7 @@ function CombineUnloaderMode:getPipeSlopeCorrection2()
     --local pipePosition = diffX * ux + diffY * uy
     --local pipePosition = -pipeDisplacement * math.sin(theta) + (nodeY - self.combineY) * math.cos(theta)
     local currentElevationCorrection = pipePosition - diffX
-    local message= 
+
     AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_COMBINEINFO, "CombineUnloaderMode:getPipeSlopeCorrection2:Normal   " ..
     ux .. "/" ..
     uy .. "/" .. 
@@ -430,16 +438,16 @@ function CombineUnloaderMode:getPipeSlopeCorrection2()
         -- Assume something has gone very wrong if the correction gets too large.
         return 0
     end
-    local elevationCorrection = currentElevationCorrection
+    --local elevationCorrection = currentElevationCorrection
     --if self.lastSlopeCorrection ~= nil then
     --    elevationCorrection = (self.lastSlopeCorrection + currentElevationCorrection)/2
     --end
 
-    self.lastSlopeCorrection = currentElevationCorrection
-    return elevationCorrection
+    --self.lastSlopeCorrection = currentElevationCorrection
+    return currentElevationCorrection
 end
 
-function CombineUnloaderMode:getPipeSlopeCorrection()
+function CombineUnloaderMode:getPipeSlopeCorrection1()
     self.combineNode = self.combine.components[1].node
     self.combineX, self.combineY, self.combineZ = getWorldTranslation(self.combineNode)
     local nodeX, nodeY, nodeZ = getWorldTranslation(AutoDrive.getDischargeNode(self.combine))
@@ -451,6 +459,10 @@ function CombineUnloaderMode:getPipeSlopeCorrection()
     local run = math.sqrt(hyp * hyp - dh * dh)
     local elevationCorrection = (hyp + (nodeY - heightUnderPipe) * (dh / hyp)) - run
     return elevationCorrection * self.pipeSide
+end
+
+function CombineUnloaderMode:getPipeSlopeCorrection()
+    return self:getPipeSlopeCorrection2()
 end
 
 function CombineUnloaderMode:getTargetTrailer()

--- a/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
+++ b/FS19_AutoDrive/scripts/Modes/CombineUnloaderMode.lua
@@ -587,12 +587,18 @@ function CombineUnloaderMode:getPipeChasePosition()
             end
         end
 
-        local leftChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, sideChaseTermX + slopeCorrection, sideChaseTermZ)
-        local rightChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, -sideChaseTermX + slopeCorrection, sideChaseTermZ)
+        local leftChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, 
+                                                                        sideChaseTermX + self:getPipeSlopeCorrection() , 
+                                                                        sideChaseTermZ)
+        local rightChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, 
+                                                                        -(sideChaseTermX + self:getPipeSlopeCorrection()),
+                                                                        sideChaseTermZ)
         local rearChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, 0, rearChaseTermZ)
         local angleToLeftChaseSide = self:getAngleToChasePos(leftChasePos)
         local angleToRearChaseSide = self:getAngleToChasePos(rearChasePos)
 
+        -- Default to the side of the harvester the unloader is already on
+        -- then check if there is a better side
         chaseNode = leftChasePos
         sideIndex = AutoDrive.CHASEPOS_LEFT
         local unloaderPos, _ = self:getUnloaderOnSide()
@@ -619,7 +625,7 @@ function CombineUnloaderMode:getPipeChasePosition()
         local combineMaxCapacity = combineFillLevel + combineLeftCapacity
         local combineFillPercent = (combineFillLevel / combineMaxCapacity) * 100
 
-        local sideChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, (sideChaseTermX * self.pipeSide) + slopeCorrection, sideChaseTermZ)
+        local sideChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, self.pipeSide * (sideChaseTermX + self:getPipeSlopeCorrection()), sideChaseTermZ)
         local rearChasePos = AutoDrive.createWayPointRelativeToVehicle(self.combine, rearChaseTermX, rearChaseTermZ)
         local angleToSideChaseSide = self:getAngleToChasePos(sideChasePos)
         local angleToRearChaseSide = self:getAngleToChasePos(rearChasePos)


### PR DESCRIPTION
After seeing the slope correction behavior cause collisions and missed unloading with certain harvesters/trailers, I believe my original solution and/or geometry is flawed. In this change set, I attempt to use the engine in my favor instead of difficult to parse geometry. That said, I plan to upload pictures of the intended geometry to bolster the cause for this change, for reference in the future, and for critique.

This is my attempt to explain the intuition in writing: The important factor causing a need for slope correction is not the absolute slope of the ground, but rather the difference in slope between what is under the pipe and what is under the combine<sup>1</sup>. So, I take the normal vector of the terrain underneath the the pipe. This gives me an instantaneous slope of the ground. I assume that this sample is sufficient to calculate the correction.<sup>2</sup> I am only interested in the affects this has in the X direction, so I convert this global direction to a direction local to the combine. I then do a [rotation of axis calculation](https://en.wikipedia.org/wiki/Rotation_of_axes) on the X direction to obtain effective pipe length, since it is moving around with the terrain. If the rotation causes the pipe to be "longer" then the correction is a positive number, otherwise negative.

The corrections produced by this change set are *much* subtler than the previous slope correction algorithm.

<sup>1. What is actually important is the total change in elevation over the run from the combine to the unloader. This is what the original algorithm attempted to do, but I think in an error prone fashion.</sup>

<sup>2. This may be an unsafe assumption on terrain that is extremely bumpy. Since the corrections are generally more subtle, though, this is probably OK. This issue also existed in the old algorithm.</sup>