### PR TITLE
Fix for Alpine DLC filltypes

### DIFF
--- a/FS19_AutoDrive/scripts/Hud.lua
+++ b/FS19_AutoDrive/scripts/Hud.lua
@@ -1,60 +1,62 @@
 AutoDriveHud = {}
 AutoDrive.FONT_SCALE = 0.0115
 AutoDrive.PULLDOWN_ITEM_COUNT = 20
-AutoDrive.ItemFilterList = {
-	34, --Air
-	--11, -- Cotton --can be transported with trailers apparently
-	77,
-	78,
-	79,
-	80, --Chicken
-	61,
-	62,
-	63,
-	64,
-	65,
-	66,
-	67,
-	68, -- Cows
-	14, --Eggs
-	--28, --29, --multiple grass
-	53,
-	54,
-	55,
-	56,
-	57,
-	58,
-	59,
-	60, --Horses
-	25, --Oilseed Radish
-	73,
-	74,
-	75,
-	76, --Pigs
-	35,
-	36,
-	37,
-	38,
-	39, --Round bale
-	69,
-	70,
-	71,
-	72, --Sheep
-	40,
-	41,
-	42, --Square bale
-	49, --Tarp?
-	22, --Tree sapling
-	1, --Unknown
-	52, --weed
-	15 --wool
-}
+AutoDrive.ItemFilterList = {}
 
 AutoDrive.pullDownListExpanded = 0
 AutoDrive.pullDownListDirection = 0
 AutoDrive.mouseWheelActive = false
 
 function AutoDriveHud:new()
+	
+	AutoDrive.ItemFilterList = {
+		g_fillTypeManager:getFillTypeIndexByName('AIR'),
+		g_fillTypeManager:getFillTypeIndexByName('CHICKEN_TYPE_BLACK'),
+		g_fillTypeManager:getFillTypeIndexByName('CHICKEN_TYPE_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('CHICKEN_TYPE_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('CHICKEN_TYPE_ROOSTER'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BROWN_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BLACK'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BLACK_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BRAHMAN_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BRAHMAN_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BRAHMAN_LIGHT_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('COW_TYPE_BRAHMAN_GREY'),
+		g_fillTypeManager:getFillTypeIndexByName('EGG'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_BEIGE'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_BLACK'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_BROWN_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_DARK_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_GREY'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_LIGHT_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('HORSE_TYPE_RED_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('OILSEEDRADISH'),
+		g_fillTypeManager:getFillTypeIndexByName('PIG_TYPE_RED'),
+		g_fillTypeManager:getFillTypeIndexByName('PIG_TYPE_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('PIG_TYPE_BLACK_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('PIG_TYPE_BLACK'),
+		g_fillTypeManager:getFillTypeIndexByName('ROUNDBALE'),
+		g_fillTypeManager:getFillTypeIndexByName('ROUNDBALE_GRASS'),
+		g_fillTypeManager:getFillTypeIndexByName('ROUNDBALE_DRYGRASS'),
+		g_fillTypeManager:getFillTypeIndexByName('ROUNDBALE_WHEAT'),
+		g_fillTypeManager:getFillTypeIndexByName('ROUNDBALE_BARLEY'),
+		g_fillTypeManager:getFillTypeIndexByName('SHEEP_TYPE_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('SHEEP_TYPE_BROWN'),
+		g_fillTypeManager:getFillTypeIndexByName('SHEEP_TYPE_BLACK_WHITE'),
+		g_fillTypeManager:getFillTypeIndexByName('SHEEP_TYPE_BLACK'),
+		g_fillTypeManager:getFillTypeIndexByName('SQUAREBALE'),
+		g_fillTypeManager:getFillTypeIndexByName('SQUAREBALE_WHEAT'),
+		g_fillTypeManager:getFillTypeIndexByName('SQUAREBALE_BARLEY'),
+		g_fillTypeManager:getFillTypeIndexByName('TARP'),
+		g_fillTypeManager:getFillTypeIndexByName('TREESAPLINGS'),
+		g_fillTypeManager:getFillTypeIndexByName('UNKNOWN'),
+		g_fillTypeManager:getFillTypeIndexByName('WEED'),
+		g_fillTypeManager:getFillTypeIndexByName('WOOL'),
+		g_fillTypeManager:getFillTypeIndexByName('ELECTRICCHARGE'),
+	}
+	
 	local o = {}
 	setmetatable(o, self)
 	self.__index = self

--- a/FS19_AutoDrive/scripts/Manager/TriggerManager.lua
+++ b/FS19_AutoDrive/scripts/Manager/TriggerManager.lua
@@ -51,11 +51,14 @@ function ADTriggerManager.checkForTriggerProximity(vehicle, distanceToTarget)
                 if distance < distanceToSlowDownAt and distanceToTarget < AutoDrive.getSetting("maxTriggerDistance") then
                     local hasRequiredFillType = false
                     local allowedFillTypes = {vehicle.ad.stateModule:getFillType()}
-                    if vehicle.ad.stateModule:getFillType() == 13 or vehicle.ad.stateModule:getFillType() == 43 or vehicle.ad.stateModule:getFillType() == 44 then
+                    
+                    local fillTypeName = g_currentMission.fillTypeManager:getFillTypeNameByIndex(vehicle.ad.stateModule:getFillType())
+                    
+                    if fillTypeName == 'SEEDS' or fillTypeName == 'FERTILIZER' or fillTypeName == 'LIQUIDFERTILIZER' then
                         allowedFillTypes = {}
-                        table.insert(allowedFillTypes, 13)
-                        table.insert(allowedFillTypes, 43)
-                        table.insert(allowedFillTypes, 44)
+                        table.insert(allowedFillTypes, g_currentMission.fillTypeManager:getFillTypeIndexByName('SEEDS'))
+                        table.insert(allowedFillTypes, g_currentMission.fillTypeManager:getFillTypeIndexByName('FERTILIZER'))
+                        table.insert(allowedFillTypes, g_currentMission.fillTypeManager:getFillTypeIndexByName('LIQUIDFERTILIZER'))
                     end
 
                     for _, trailer in pairs(allFillables) do
@@ -208,9 +211,11 @@ end
 function ADTriggerManager.getRefuelTriggers(vehicle)
     local refuelTriggers = {}
 
+    local fuelFillTypeIndex = g_currentMission.fillTypeManager:getFillTypeIndexByName('DIESEL')
+    
     for _, trigger in pairs(ADTriggerManager.getLoadTriggers()) do
         --loadTriggers
-        if trigger.source ~= nil and trigger.source.providedFillTypes ~= nil and trigger.source.providedFillTypes[32] then
+        if trigger.source ~= nil and trigger.source.providedFillTypes ~= nil and trigger.source.providedFillTypes[fuelFillTypeIndex] then
             local fillLevels = {}
             if trigger.source ~= nil and trigger.source.getAllFillLevels ~= nil then
                 fillLevels, _ = trigger.source:getAllFillLevels(vehicle:getOwnerFarmId())
@@ -226,7 +231,7 @@ function ADTriggerManager.getRefuelTriggers(vehicle)
                     end
                 end
             end
-            local hasCapacity = trigger.hasInfiniteCapacity or (fillLevels[32] ~= nil and fillLevels[32] > 0) or (gcFillLevels[32] ~= nil and gcFillLevels[32] > 0)
+            local hasCapacity = trigger.hasInfiniteCapacity or (fillLevels[fuelFillTypeIndex] ~= nil and fillLevels[fuelFillTypeIndex] > 0) or (gcFillLevels[fuelFillTypeIndex] ~= nil and gcFillLevels[fuelFillTypeIndex] > 0)
 
             if hasCapacity then
                 table.insert(refuelTriggers, trigger)

--- a/FS19_AutoDrive/scripts/Modules/TrailerModule.lua
+++ b/FS19_AutoDrive/scripts/Modules/TrailerModule.lua
@@ -279,14 +279,15 @@ function ADTrailerModule:startLoadingCorrectFillTypeAtTrigger(trailer, trigger, 
     AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_TRAILERINFO, "[AD] ADTrailerModule:startLoadingCorrectFillTypeAtTrigger start")
     if not AutoDrive.fillTypesMatch(self.vehicle, trigger, trailer) then
         local storedFillType = self.vehicle.ad.stateModule:getFillType()
-        local toCheck = {13, 43, 44}
+        local toCheck = {'SEEDS','FERTILIZER','LIQUIDFERTILIZER'}
 
-        for _, fillType in pairs(toCheck) do
-            self.vehicle.ad.stateModule:setFillType(fillType)
+        for _, fillTypeName in pairs(toCheck) do
+            local fillTypeIndex = g_currentMission.fillTypeManager:getFillTypeIndexByName(fillTypeName)
+            self.vehicle.ad.stateModule:setFillType(fillTypeIndex)
             if AutoDrive.fillTypesMatch(self.vehicle, trigger, trailer, nil, fillUnitIndex) then
-                self:startLoadingAtTrigger(trigger, fillType, fillUnitIndex, trailer)
+                self:startLoadingAtTrigger(trigger, fillTypeIndex, fillUnitIndex, trailer)
                 self.vehicle.ad.stateModule:setFillType(storedFillType)
-                AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_TRAILERINFO, "[AD] ADTrailerModule:startLoadingCorrectFillTypeAtTrigger found fillType 13, 43, 44 - return")
+                AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_TRAILERINFO, "[AD] ADTrailerModule:startLoadingCorrectFillTypeAtTrigger found fillType 'SEEDS','FERTILIZER','LIQUIDFERTILIZER' - return")
                 return
             end
         end

--- a/FS19_AutoDrive/scripts/Tasks/RefuelTask.lua
+++ b/FS19_AutoDrive/scripts/Tasks/RefuelTask.lua
@@ -99,10 +99,13 @@ end
 function RefuelTask:startRefueling()
     if (not self.refuelTrigger.isLoading) and (not self.isRefueled) then
         AutoDrive.debugPrint(self.vehicle, AutoDrive.DC_VEHICLEINFO, "Start refueling")
+        
+        local fuelFillTypeIndex = g_currentMission.fillTypeManager:getFillTypeIndexByName('DIESEL')
+        
         self.refuelTrigger.autoStart = true
-        self.refuelTrigger.selectedFillType = 32
-        self.refuelTrigger:onFillTypeSelection(32)
-        self.refuelTrigger.selectedFillType = 32
+        self.refuelTrigger.selectedFillType = fuelFillTypeIndex
+        self.refuelTrigger:onFillTypeSelection(fuelFillTypeIndex)
+        self.refuelTrigger.selectedFillType = fuelFillTypeIndex
         self.hasRefueled = true
         g_effectManager:setFillType(self.refuelTrigger.effects, self.refuelTrigger.selectedFillType)
     end

--- a/FS19_AutoDrive/scripts/Utils/TrailerUtil.lua
+++ b/FS19_AutoDrive/scripts/Utils/TrailerUtil.lua
@@ -295,7 +295,10 @@ function AutoDrive.getFilteredFillLevelAndCapacityOfOneUnit(object, fillUnitInde
     local isSelectedFillType = false
     local hasOnlyDieselForFuel = AutoDrive.checkForDieselTankOnlyFuel(object)
     for fillType, _ in pairs(object:getFillUnitSupportedFillTypes(fillUnitIndex)) do
-        if (fillType == 1 or fillType == 34 or fillType == 33 or fillType == 32) then --1:UNKNOWN 34:AIR 33:AdBlue 32:Diesel
+        
+        local fillTypeName = g_currentMission.fillTypeManager:getFillTypeNameByIndex(fillType)
+        
+        if (fillTypeName == 'UNKNOWN' or fillTypeName == 'ELECTRICCHARGE' or fillTypeName == 'AIR' or fillTypeName == 'DEF' or fillTypeName == 'DIESEL') then --1:UNKNOWN 34:AIR 33:AdBlue 32:Diesel
             if object.isEntered ~= nil or hasOnlyDieselForFuel then
                 fillTypeIsProhibited = true
             end
@@ -327,10 +330,13 @@ function AutoDrive.checkForDieselTankOnlyFuel(object)
         numberOfFillUnits = numberOfFillUnits + 1
         local dieselFillUnit = false
         for fillType, _ in pairs(object:getFillUnitSupportedFillTypes(fillUnitIndex)) do
-            if fillType == 33 then
+            
+            local fillTypeName = g_currentMission.fillTypeManager:getFillTypeNameByIndex(fillType)
+            
+            if fillTypeName == 'DEF' then
                 adBlueUnitCount = adBlueUnitCount + 1
             end
-            if fillType == 32 then
+            if fillTypeName == 'DIESEL' then
                 dieselFuelUnitCount = dieselFuelUnitCount + 1
                 dieselFillUnit = true
             end
@@ -446,11 +452,14 @@ function AutoDrive.getTriggerAndTrailerPairs(vehicle, dt)
                     local allowedFillTypes = {vehicle.ad.stateModule:getFillType()}
                     local fillUnits = trailer:getFillUnits()
                     if #fillUnits > 1 then
-                        if vehicle.ad.stateModule:getFillType() == 13 or vehicle.ad.stateModule:getFillType() == 43 or vehicle.ad.stateModule:getFillType() == 44 then
+                                                
+                        local fillTypeName = g_currentMission.fillTypeManager:getFillTypeNameByIndex(vehicle.ad.stateModule:getFillType())
+                        
+                        if fillTypeName == 'SEEDS' or fillTypeName == 'FERTILIZER' or fillTypeName == 'LIQUIDFERTILIZER' then
                             allowedFillTypes = {}
-                            table.insert(allowedFillTypes, 13)
-                            table.insert(allowedFillTypes, 43)
-                            table.insert(allowedFillTypes, 44)
+                            table.insert(allowedFillTypes, g_currentMission.fillTypeManager:getFillTypeIndexByName('SEEDS'))
+                            table.insert(allowedFillTypes, g_currentMission.fillTypeManager:getFillTypeIndexByName('FERTILIZER'))
+                            table.insert(allowedFillTypes, g_currentMission.fillTypeManager:getFillTypeIndexByName('LIQUIDFERTILIZER'))
                         end
                     end
 


### PR DESCRIPTION
In Alpine DLC Giants introduced new fillType - ELECTRICCHARGE - type of "fuel" for electric tractors. Unfortunately, they put it in the fillType table under the index 1, thus shifting all other fillTypes' indexes up by one. AutoDrive used some of those indexes explicitly (as a number) for some calculation, therefore creating the issue where the fillLevel of tractor+trailer combos were calculated incorrectly. The trailer would empty on the trigger, but AD continued to calculate the fillLevel incorrectly and since according to AD it was > 0, the vehicles would not move from the destination trigger.

I searched through all the files and replace all occurrences where fillTypes' indexes were used explicitly to ones based on the fillType names. I hope I got them all.

My experience in lua programming, and especially in scripting FS mods, is very basic. I'm not sure when to use specific methods like, for example: g_currentMission.fillTypeManager vs. g_fillTypeManager so please check my changes thoroughly.

Fixes (hopefully) issue #1657