### PR TITLE
FIX height calculation when moving waypoints

### DIFF
--- a/FS19_AutoDrive/scripts/Hud.lua
+++ b/FS19_AutoDrive/scripts/Hud.lua
@@ -463,7 +463,7 @@ function AutoDriveHud:mouseEvent(vehicle, posX, posY, isDown, isUp, button)
 
                         local x, y, z = unProject(g_lastMousePosX, g_lastMousePosY, depth)
                         -- And just to correct for slope changes, we now set the height to the terrain height
-                        y = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, x, 1, z)
+                        y = AutoDrive:getTerrainHeightAtWorldPos(x, z)
 
                         local screenX, screenY, depthNew = project(x, y + AutoDrive.drawHeight + AutoDrive.getSetting("lineHeight"), z)
 
@@ -479,7 +479,7 @@ function AutoDriveHud:mouseEvent(vehicle, posX, posY, isDown, isUp, button)
                             end
 
                             x, y, z = unProject(g_lastMousePosX, g_lastMousePosY, depth)
-                            y = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, x, 1, z)
+                            y = AutoDrive:getTerrainHeightAtWorldPos(x, z)
 
                             screenX, screenY, depthNew = project(x, y + AutoDrive.drawHeight + AutoDrive.getSetting("lineHeight"), z)
 
@@ -538,27 +538,7 @@ function AutoDrive.moveNodeToMousePos(nodeID)
 
 	if node ~= nil and g_lastMousePosX ~= nil and g_lastMousePosY ~= nil then
 		node.x, _, node.z = unProject(g_lastMousePosX, g_lastMousePosY, depth)
-		local collisions = overlapBox(node.x, node.y, node.z, 0, 0, 0, 0.1, 0.1, 0.1, "collisionTestCallback", nil, ADCollSensor.collisionMask, true, true, true)
-		local maxLoops = 10
-		local safeNodeY = node.y
-		while collisions > 0 and maxLoops > 0 do
-			maxLoops = maxLoops - 1
-			node.y = node.y + 0.1
-			safeNodeY = node.y
-			collisions = overlapBox(node.x, node.y, node.z, 0, 0, 0, 0.1, 0.1, 0.1, "collisionTestCallback", nil, ADCollSensor.collisionMask, true, true, true)
-		end
-
-		-- Once again, try if we can't find a proper floor level here
-		maxLoops = 10
-		node.y = node.y - 0.1
-		collisions = overlapBox(node.x, node.y - 0.1, node.z, 0, 0, 0, 0.5, 0.5, 0.5, "collisionTestCallback", nil, ADCollSensor.collisionMask, true, true, true)
-		while collisions == 0 and maxLoops > 0 do
-			maxLoops = maxLoops - 1
-			safeNodeY = node.y
-			node.y = node.y - 0.1
-			collisions = overlapBox(node.x, node.y, node.z, 0, 0, 0, 0.1, 0.1, 0.1, "collisionTestCallback", nil, ADCollSensor.collisionMask, true, true, true)
-		end
-		node.y = math.max(safeNodeY - 0.2, getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, node.x, 1, node.z))
+		node.y = AutoDrive:getTerrainHeightAtWorldPos(node.x, node.z)
 		ADGraphManager:markChanges()
 	end
 end

--- a/FS19_AutoDrive/scripts/Utils/UtilFuncs.lua
+++ b/FS19_AutoDrive/scripts/Utils/UtilFuncs.lua
@@ -76,7 +76,7 @@ function AutoDrive:getTerrainHeightAtWorldPos(x, z)
 	-- get a starting height with the basic function
 	local y = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, x, 1, z)
 	-- do a raycast from a bit above y
-	raycastClosest(x, y + 2, z, 0, -1, 0, "getTerrainHeightAtWorldPos_Callback", 10, self, 12)
+	raycastClosest(x, y + 9, z, 0, -1, 0, "getTerrainHeightAtWorldPos_Callback", 10, self, 12)
 	return self.raycastHeight or y
 end
 

--- a/FS19_AutoDrive/scripts/Utils/UtilFuncs.lua
+++ b/FS19_AutoDrive/scripts/Utils/UtilFuncs.lua
@@ -63,6 +63,28 @@ string.randomCharset = {
 	"z"
 }
 
+--- Calculates a much better result of world height by using a raycast.
+--- The original function `getTerrainHeightAtWorldPos` returns wrong results if, for example, the terrain underneath a road has gaps.
+--- As the raycast uses a callback function, this function must be splitted in two parts.
+--- We're using collision mask of 12 (bit 3&4) - see: ADCollSensor.mask_static_world*
+--- see: https://gdn.giants-software.com/thread.php?categoryId=3&threadId=8381
+--- @param x number X Coordinate
+--- @param z number Z Coordinate
+--- @return number Height of the terrain
+function AutoDrive:getTerrainHeightAtWorldPos(x, z)
+	self.raycastHeight = nil
+	-- get a starting height with the basic function
+	local y = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, x, 1, z)
+	-- do a raycast from a bit above y
+	raycastClosest(x, y + 2, z, 0, -1, 0, "getTerrainHeightAtWorldPos_Callback", 10, self, 12)
+	return self.raycastHeight or y
+end
+
+--- Callback function called by AutoDrive:getTerrainHeightAtWorldPos()
+function AutoDrive:getTerrainHeightAtWorldPos_Callback(hitObjectId, x, y, z, distance)
+	self.raycastHeight = y
+end
+
 function AutoDrive.streamReadStringOrEmpty(streamId)
 	local string = streamReadString(streamId)
 	if string == nil or string == "nil" then


### PR DESCRIPTION
Hi guys,

while testing my smooth curves feature, I hit the problem that my waypoints sunk into the ground.  Basically the same happened with "normal" AD waypoints when moving them manually, for example at the T-shape in Felsbrunn right in front of the farm.

![beforeRaycast](https://user-images.githubusercontent.com/1003878/104109143-1fc86e80-52cb-11eb-8ea1-e2b06541113e.png)

Doing some research, I found a hint, that the widely used `getTerrainHeightAtWorldPos` returns the height of the terrain which is not the same as the height of a road. On some maps there are gaps under the road which leads to the described problem.
By exchanging the function with a raycast I got a much better and more accurate result. 

![withRaycast](https://user-images.githubusercontent.com/1003878/104109168-8f3e5e00-52cb-11eb-8153-c5770480e72d.png)

So technically, the new method might be a bit slower but should give much better results.
Personally, for me the only reason to change the drawing height above the vehicle was to work around waypoints that sunk underneath the road...

I commented out lot of the `moveNodeToMousePos` function, because replacing all this with just one line looks way to easy and maybe I missed something ? :-)