### PR TITLE
Feature Requst - Change active lights "off the field" at night

### DIFF
--- a/FS19_AutoDrive/gui/vehicleSettingsPage.xml
+++ b/FS19_AutoDrive/gui/vehicleSettingsPage.xml
@@ -146,6 +146,14 @@
 					<GuiElement type="bitmap" profile="multiTextOptionSettingsBg" />
 					<GuiElement type="bitmap" profile="baseReference" screenAlign="topLeft" position="5px 4px" size="17px 17px" />
 				</GuiElement>
+				<GuiElement type="multiTextOption" profile="multiTextOptionSettings" onCreate="onCreateAutoDriveSetting" onClick="onOptionChange" name="offFieldLights" toolTipElementId="ingameMenuHelpBoxText">
+					<GuiElement type="button" profile="multiTextOptionSettingsLeft" />
+					<GuiElement type="button" profile="multiTextOptionSettingsRight" />
+					<GuiElement type="text" profile="multiTextOptionSettingsText" />
+					<GuiElement type="text" profile="multiTextOptionSettingsTitle" position="27px 6px" />
+					<GuiElement type="bitmap" profile="multiTextOptionSettingsBg" />
+					<GuiElement type="bitmap" profile="baseReference" screenAlign="topLeft" position="5px 4px" size="17px 17px" />
+				</GuiElement>
 			</GuiElement>
 		</GuiElement>
 

--- a/FS19_AutoDrive/scripts/Settings.lua
+++ b/FS19_AutoDrive/scripts/Settings.lua
@@ -926,6 +926,17 @@ AutoDrive.settings.autoTrailerCover = {
     isVehicleSpecific = true
 }
 
+AutoDrive.settings.offFieldLights = {
+    values = {0, 1, 2, 3, 4, 5, 6, 7},
+    texts = { "gui_ad_LightsSetting0", "gui_ad_LightsSetting1", "gui_ad_LightsSetting2", "gui_ad_LightsSetting3", "gui_ad_LightsSetting4", "gui_ad_LightsSetting5", "gui_ad_LightsSetting6", "gui_ad_LightsSetting7" },
+    default = 2,
+    current = 2,
+    text = "gui_ad_offFieldLights",
+    tooltip = "gui_ad_offFieldLights_tooltip",
+    translate = true,
+    isVehicleSpecific = true
+}
+
 function AutoDrive.getSetting(settingName, vehicle)
     if AutoDrive.settings[settingName] ~= nil then
         local setting = AutoDrive.settings[settingName]

--- a/FS19_AutoDrive/scripts/Specialization.lua
+++ b/FS19_AutoDrive/scripts/Specialization.lua
@@ -962,7 +962,13 @@ function AutoDrive:updateAILights(superFunc)
                 self:setLightsTypesMask(spec.aiLightsTypesMask)
             end
             if spec.lightsTypesMask ~= 1 and not AutoDrive.checkIsOnField(x, y, z) then
-                self:setLightsTypesMask(1)
+                local lightSetting = AutoDrive.getSetting("offFieldLights", self)
+
+                if lightSetting ~= nil then
+                    self:setLightsTypesMask(lightSetting)
+                else
+                    self:setLightsTypesMask(1)
+                end
             end
         else
             if spec.lightsTypesMask ~= 0 then

--- a/FS19_AutoDrive/translations/translation_br.xml
+++ b/FS19_AutoDrive/translations/translation_br.xml
@@ -186,6 +186,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Automatic Trailer Covers" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Yes - AutoDrive open and close trailer covers as needed / No - trailer covers will not be opened or closed by AutoDrive" />
 
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+		
 		<text name="gui_ad_settingsPage_title"					text="Settings - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="User Settings - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Vehicle Settings - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_cz.xml
+++ b/FS19_AutoDrive/translations/translation_cz.xml
@@ -186,6 +186,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Automatické plachtování přívěsu" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Ano - AutoDrive podle potřeby otevírá a zavírá kryty přívěsu / Ne - kryty přívěsu nebude AutoDrive otevírat ani zavírat" />
 		
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Nastavení - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="Uživatelské nastavení - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Nastavení vozidla - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_de.xml
+++ b/FS19_AutoDrive/translations/translation_de.xml
@@ -184,6 +184,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Automatische Abdeckungen" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Ja - AutoDrive öffnet und schließt Abdeckungen von Anhängern wenn notwendig / Nein - die Abdeckungen werden von AutoDrive nicht geöffnet oder geschlossen" />
 		
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Einstellungen - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="User Settings - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Fahrzeugeinstellungen - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_en.xml
+++ b/FS19_AutoDrive/translations/translation_en.xml
@@ -184,6 +184,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Automatic Trailer Covers" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Yes - AutoDrive open and close trailer covers as needed / No - trailer covers will not be opened or closed by AutoDrive" />
 
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Settings - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="User Settings - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Vehicle Settings - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_es.xml
+++ b/FS19_AutoDrive/translations/translation_es.xml
@@ -184,6 +184,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Lonas de remolque automáticas" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Sí - AutoDrive abrirá y cerrará las lonas según necesite / No - las lonas no se abrirán ni cerrarán automáticamente" />
 		
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Ajustes - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="Ajustes de usuario - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Ajustes del vehículo - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_fr.xml
+++ b/FS19_AutoDrive/translations/translation_fr.xml
@@ -172,6 +172,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Bâches remorques automatique" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Oui - AutoDrive ouvre et ferme les bâches remorque au besoin / Non - les bâches remorque ne seront pas ouvertes ou fermées par AutoDrive" />
 
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_followOnlyOnField"					text="Restreindre au champ..." />
 		<text name="gui_ad_followOnlyOnField_tooltip"			text="Restreindre le déchargement au champ pendant le déchargement actif" />
 		<text name="gui_ad_addSettingsToHUD"					text="Ajouter des paramètres au HUD" />

--- a/FS19_AutoDrive/translations/translation_hu.xml
+++ b/FS19_AutoDrive/translations/translation_hu.xml
@@ -183,6 +183,18 @@
 		<text name="gui_ad_autoTipSide_tooltip"                 text="Igen - Az AutoDrive automatikusan kiválasztja a csúcsoldalt / Nem - a már kiválasztott csúcsoldalt fogja használni" />
 		<text name="gui_ad_autoTrailerCover"                    text="Automatikus pótkocsi fedél " />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Igen - az AutoDrive szükség esetén nyissa meg és zárja be a pótkocsi fedelét / Nem - az AutoDrive nem nyitja vagy zárja le a pótkocsi fedelét" />
+
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Beállítás - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="Felhasználói beállítások - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Jármű beállítás - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_it.xml
+++ b/FS19_AutoDrive/translations/translation_it.xml
@@ -186,6 +186,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Copertura automatica del rimorchio" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Sì - AutoDrive apre e chiude le coperture del rimorchio secondo necessità / No - le coperture del rimorchio non verranno aperte o chiuse da AutoDrive" />
 		
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Impostazioni" />
 		<text name="gui_ad_userSettingsPage_title"				text="Impostazioni Utente" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Impostazioni Veicolo" />

--- a/FS19_AutoDrive/translations/translation_nl.xml
+++ b/FS19_AutoDrive/translations/translation_nl.xml
@@ -186,6 +186,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Automatic Trailer Covers" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Yes - AutoDrive open and close trailer covers as needed / No - trailer covers will not be opened or closed by AutoDrive" />
 		
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Instellingen - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="User Settings - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Voertuiginstellingen - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_pl.xml
+++ b/FS19_AutoDrive/translations/translation_pl.xml
@@ -184,6 +184,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Automatic Trailer Covers" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Yes - AutoDrive open and close trailer covers as needed / No - trailer covers will not be opened or closed by AutoDrive" />
 		
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Ustawienia - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="User Settings - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Ustawienia pojazdu - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_pt.xml
+++ b/FS19_AutoDrive/translations/translation_pt.xml
@@ -187,6 +187,17 @@
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Sim - o AutoDrive abre e fecha as coberturas dos reboques conforme necessário / Não - as coberturas dos reboques não serão abertas ou fechadas pela AutoDrive" />
 
 
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 
 		
 		

--- a/FS19_AutoDrive/translations/translation_ru.xml
+++ b/FS19_AutoDrive/translations/translation_ru.xml
@@ -186,6 +186,17 @@
 		<text name="gui_ad_autoTrailerCover"                    text="Тенты на прицепах" />
 		<text name="gui_ad_autoTrailerCover_tooltip"            text="Да - AutoDrive открывает и закрывает тенты по мере необходимости / Нет - тенты прицепа не открываются или закрываются с помощью AutoDrive." />
 
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
 		<text name="gui_ad_settingsPage_title"					text="Общие настройки - AutoDrive" />
 		<text name="gui_ad_userSettingsPage_title"				text="Пользовательские настройки - AutoDrive" />
 		<text name="gui_ad_vehicleSettingsPage_title"			text="Настройки техники - AutoDrive" />

--- a/FS19_AutoDrive/translations/translation_tr.xml
+++ b/FS19_AutoDrive/translations/translation_tr.xml
@@ -184,6 +184,17 @@
     <text name="gui_ad_autoTrailerCover"                                                                text="Otomatik römork kapakları"  />
     <text name="gui_ad_autoTrailerCover_tooltip"                                                        text="Evet - AutoDrive gerektiğinde römork kapaklarını açıp kapat / Hayır - römork kapakları AutoDrive tarafından açılmayacak veya kapanmayacak"  />
                                                                                                         
+		<text name="gui_ad_offFieldLights"						text="Night Driving Lights" />
+		<text name="gui_ad_offFieldLights_tooltip"				text="Light set for off-field Night Driving (Default = Headlights)" />
+		<text name="gui_ad_LightsSetting0"						text="No Lights" />
+		<text name="gui_ad_LightsSetting1"						text="Headlights" />
+		<text name="gui_ad_LightsSetting2"						text="Back Worklights" />
+		<text name="gui_ad_LightsSetting3"						text="Headlights + Back Worklights" />
+		<text name="gui_ad_LightsSetting4"						text="Front Worklights" />
+		<text name="gui_ad_LightsSetting5"						text="Headlights + Front Worklights" />
+		<text name="gui_ad_LightsSetting6"						text="Front + Back Worklights" />
+		<text name="gui_ad_LightsSetting7"						text="All Lights" />
+
     <text name="gui_ad_settingsPage_title"                                                              text="Ayarlar - AutoDrive"  />
     <text name="gui_ad_userSettingsPage_title"                                                          text="Kullanıcı Ayarları - AutoDrive"  />
     <text name="gui_ad_vehicleSettingsPage_title"                                                       text="Araç Ayarları - AutoDrive"  />


### PR DESCRIPTION
## Why this setting is being suggested:

A fair few of the newer truck and semi mods available are using the existing light system in non-standard ways to provide more "pretty" decoration.  Of note, the RoadRunner+ (modhub) uses LightType=0 (supposed to be headlights) as parking lights, and LightType=2 (supposed to be front works) as the actual headlights.  Similarly, the NMC Reaper Pack (modhub) uses headlights (type 0) as decoration, and the rear worklights (type 1) as the real headlights.  In both of these cases, the lightType I defined as the "real headlights" is the lightType that contains the &lt;realLights> of the mod. Of course, when AutoDrive currently turns on what should be the headlights, the truck proceeds to drive around mostly in the dark.

## What I Did:

Added a setting called "Night Driving Lights" that allows the user, on a per-vehicle basis, to choose which set of lights to illuminate.  I used the "proper" names of the lights, because there is no way of knowing what the mod author actually did.

![settingscreen](https://user-images.githubusercontent.com/605986/108639229-6d411980-74ce-11eb-8d79-2c0de649fee5.png)

## What and How I tested:

I used a number of vanilla vehicles, along with a few modded vehicles I knew are currently "broken" and ran a few in-game days.  Some screenshots below...

![onfield-nochange](https://user-images.githubusercontent.com/605986/108639253-8ea20580-74ce-11eb-80a3-9951f9fa7921.png)
__"Broken" Tractor, on the field.  No change to existing behavior, _aiLightsTypeMask_ is used for a vehicle working in the field__

![moved-offfield-overridden](https://user-images.githubusercontent.com/605986/108639292-bb561d00-74ce-11eb-8b3e-4627243e1a45.png)
__Same "Broken" Tractor, having just moved off the field, with the new setting on "_Headlights + Front Worklights_"__
a/n: Yes, the parking lights should probably be off for road driving, which would be the _"Front Worklights"_ setting, but they are really pretty.

![offfield-standardheadlights](https://user-images.githubusercontent.com/605986/108639314-d9238200-74ce-11eb-9f52-227a16f8251b.png)
__Vanilla tractor, off the field, with no setting change - behavior is what it has always been__

![offfield-overridenstandard1](https://user-images.githubusercontent.com/605986/108639337-f0626f80-74ce-11eb-8688-218ae5262e25.png)
__Vanilla Semi, off the field, with the setting overridden to "_Headlights + Front Worklights_" to show possibilities__

## Settings available:

 * "No Lights"
 * "Headlights" - the current setting used
 * "Back Worklights"
 * "Headlights + Back Worklights"
 * "Front Worklights"
 * "Headlights + Front Worklights"
 * "Front + Back Worklights"
 * "All Lights" - the equivalent of _aiLightsTypesMask_


## What doesn't work quite right

So, being that I am unfamiliar with all the ins and outs of how AutoDrive works under the hood, I have notice that changing the setting does not take effect until you switch vehicles (or get in and get out).  I would guess this is because of when the per-vehicle settings are read, or perhaps I am reading the setting in scripts/Specialization.lua incorrectly.

Additionally, I wasn't sure exactly how i18n is handled by AutoDrive, so I did add the english version of all of these terms to each of the translation files - if this is the improper method, let me know and I can back those changes out of the commit.  My apologies, as I am not even bi-lingual, and can be of no help in the translation.

### Other bits I didn't add, but thought about

I made a short attempt at a "Daytime Running Lights" option too, but I was unsuccessful - is updateAILights not called if the vehicle is started in the daytime? (It is also entirely possible that I simply mistyped something)

I would also be interested in a "use Hazard Lights" for road driving - at least where I am in the US, it wouldn't be odd to see an oversized load with both beacons and hazards running - the giant seed drill / air carts come to mind (My JD 9620RX with 1870 seed drill, and c850 air cart would look fantastic running down the road with the beacons and hazards blaring)

