### PR TITLE
Start/Stop Courseplay fixed

### DIFF
--- a/FS19_AutoDrive/scripts/ExternalInterface.lua
+++ b/FS19_AutoDrive/scripts/ExternalInterface.lua
@@ -201,6 +201,16 @@ function AutoDrive:combineIsCallingDriver(combine)
     return ADHarvestManager.doesHarvesterNeedUnloading(combine, true)
 end
 
+function AutoDrive:StartCP(vehicle)
+    if vehicle.startCpDriver then
+        -- newer CP versions use this function to start the CP driver
+        vehicle:startCpDriver()
+    else
+        -- for backward compatibility for older CP versions
+        g_courseplay.courseplay:start(vehicle)
+    end
+end
+
 -- stop CP if it is active
 function AutoDrive:StopCP(vehicle)
 	if vehicle == nil then 
@@ -212,7 +222,13 @@ function AutoDrive:StopCP(vehicle)
 			vehicle.ad.stateModule:toggleStartCP_AIVE()
 		end
         AutoDrive.debugPrint(vehicle, AutoDrive.DC_EXTERNALINTERFACEINFO, "AutoDrive:StopCP call CP stop")
-		g_courseplay.courseplay:stop(vehicle)
+        if vehicle.stopCpDriver then
+            -- newer CP versions use this function to stop the CP driver
+            vehicle:stopCpDriver()
+        else
+            -- for backward compatibility for older CP versions
+            g_courseplay.courseplay:stop(vehicle)
+        end
 	end
 end
 

--- a/FS19_AutoDrive/scripts/Specialization.lua
+++ b/FS19_AutoDrive/scripts/Specialization.lua
@@ -764,7 +764,7 @@ function AutoDrive:stopAutoDrive()
                     self.ad.stateModule:setStartCP_AIVE(false)
                     if g_courseplay ~= nil and self.ad.stateModule:getUseCP_AIVE() then
                         AutoDrive.debugPrint(self, AutoDrive.DC_EXTERNALINTERFACEINFO, "AutoDrive:stopAutoDrive pass control to CP with start")
-                        g_courseplay.courseplay:start(self)
+                        AutoDrive:StartCP(self)
                     else
                         if self.acParameters ~= nil then
                             self.acParameters.enabled = true


### PR DESCRIPTION
The Courseplay team broke the courseplay:start() interface, that
can't be used anymore to start the CP driver.

This fix addresses that issue (see: https://github.com/Courseplay/courseplay/issues/7062)

Courseplay driver. These will be part of the Courseplay version > 6.03.00053.

Kept the old start/stop call for backward compatibility.

Moved the start code to ExternalInterface.lua.

It seems like AutoDrive:StopCP() isn't called for example when AD
runs a refill course for CP and AD is stopped, the AD team may want
to look at that.
